### PR TITLE
Update exceptions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Import the `Onfido` object, this is the main object used for interfacing with th
 
 ```java
 import com.onfido.Onfido;
+
+import com.onfido.exceptions.ApiException;
+import com.onfido.exceptions.OnfidoException;
 ```
 
 Instantiate and configure an `Onfido` instance with your API token, and region if necessary:
@@ -48,12 +51,14 @@ try {
     Applicant newApplicant = onfido.applicant.create(
             Applicant.request().firstName("First").lastName("Last")
     );
-} catch (OnfidoException ex) {
-    // An error response was received from the Onfido API.
-    System.out.println(ex.getMessage());
-} catch (Exception ex) {
+} catch (ApiException e) {
+    // An error response was received from the Onfido API, extra info is available.
+    System.out.println(e.getMessage());
+    System.out.println(e.getType());
+    System.out.println(e.isClientError());
+} catch (OnfidoException e) {
     // No response was received for some reason e.g. a network error.
-    throw ex;
+    System.out.println(e.getMessage());
 }
 ```
 
@@ -65,14 +70,12 @@ newApplicant.getFirstName();
 
 ## Contributing
 
-1. Fork it ( https://github.com/onfido/onfido/fork )
+1. Fork it (<https://github.com/onfido/onfido/fork>)
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create a new Pull Request
 
-
 ## More Documentation
 
 More documentation and code examples can be found at <https://documentation.onfido.com>
-


### PR DESCRIPTION
## Description

Minor change to the README: API actions should only throw either an `ApiException` or its parent `OnfidoException`, rather than a generic `Exception`.