### PR TITLE
Handle passing a null apiToken

### DIFF
--- a/onfido-java/src/main/java/com/onfido/Onfido.java
+++ b/onfido-java/src/main/java/com/onfido/Onfido.java
@@ -60,7 +60,7 @@ public final class Onfido {
      * @return the Onfido
      */
     public Onfido build() {
-      if (apiToken.isEmpty()) {
+      if (apiToken == null || apiToken.isEmpty()) {
         throw new RuntimeException("Please provide an apiToken");
       }
 

--- a/onfido-java/src/test/java/com/onfido/OnfidoTest.java
+++ b/onfido-java/src/test/java/com/onfido/OnfidoTest.java
@@ -7,4 +7,9 @@ public class OnfidoTest {
   public void throwsExceptionForMissingApiToken() {
     Onfido.builder().build();
   }
+
+  @Test(expectedExceptions = RuntimeException.class)
+  public void throwsExceptionForNullApiToken() {
+    Onfido.builder().apiToken(null).build();
+  }
 }


### PR DESCRIPTION
## Description

Small fix for #16 - when doing `.apiToken(null)` you get a NPE and it isn't very easy to see why if you're doing something like this:

```java
Onfido.builder().apiToken(System.getenv("ONFIDO_API_TOKEN")).build();
```

I'm undecided on whether to do a 1.0.1 release for this or just wait for a future release