### PR TITLE
Fix downloads issue

### DIFF
--- a/onfido-java/pom.xml
+++ b/onfido-java/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.onfido</groupId>
     <artifactId>onfido-api-java</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
 
     <name>Onfido API Java Client</name>
     <description>Official Java API client library for the Onfido API</description>

--- a/onfido-java/src/main/java/com/onfido/api/FileDownload.java
+++ b/onfido-java/src/main/java/com/onfido/api/FileDownload.java
@@ -1,14 +1,12 @@
 package com.onfido.api;
 
-import java.io.InputStream;
-
 /**
  * A wrapper class for any file downloaded from the API. Stores an content as an InputStream and
  * file type as a String.
  */
 public class FileDownload {
   /** The content of the downloaded file. */
-  public final InputStream content;
+  public final byte[] content;
   /** The file type of the associated content. */
   public final String contentType;
 
@@ -18,7 +16,7 @@ public class FileDownload {
    * @param content the content of the file
    * @param contentType the file type of the associated content
    */
-  public FileDownload(InputStream content, String contentType) {
+  public FileDownload(byte[] content, String contentType) {
     this.content = content;
     this.contentType = contentType;
   }

--- a/onfido-java/src/main/java/com/onfido/api/ResourceManager.java
+++ b/onfido-java/src/main/java/com/onfido/api/ResourceManager.java
@@ -156,7 +156,7 @@ public abstract class ResourceManager {
   private FileDownload performDownload(Request request) throws OnfidoException {
     try (Response response = client.newCall(request).execute()) {
       if (response.isSuccessful()) {
-        return new FileDownload(response.body().byteStream(), response.header("content-type"));
+        return new FileDownload(response.body().bytes(), response.header("content-type"));
       } else {
         throw ApiException.fromResponseBody(response.body().string(), response.code());
       }

--- a/onfido-java/src/test/java/com/onfido/integration/ApiIntegrationTest.java
+++ b/onfido-java/src/test/java/com/onfido/integration/ApiIntegrationTest.java
@@ -30,11 +30,9 @@ class ApiIntegrationTest {
     return server;
   }
 
-  protected MockWebServer mockFileRequestResponse() throws IOException {
-    Buffer buffer = new Buffer();
-    buffer.writeInt(5);
+  protected MockWebServer mockFileRequestResponse(String content, String type) throws IOException {
     server = new MockWebServer();
-    server.enqueue(new MockResponse().setBody(buffer));
+    server.enqueue(new MockResponse().setBody(content).addHeader("content-type", type));
     server.start();
 
     return server;

--- a/onfido-java/src/test/java/com/onfido/integration/DocumentManagerTest.java
+++ b/onfido-java/src/test/java/com/onfido/integration/DocumentManagerTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.onfido.JsonObject;
 import com.onfido.Onfido;
+import com.onfido.api.FileDownload;
 import com.onfido.exceptions.ApiException;
 import com.onfido.models.Document;
 import java.io.ByteArrayInputStream;
@@ -58,19 +59,20 @@ public class DocumentManagerTest extends ApiIntegrationTest {
 
   @Test
   public void downloadDocument() throws Exception {
-    MockWebServer server = mockFileRequestResponse();
+    MockWebServer server = mockFileRequestResponse("test", "image/png");
 
     Onfido onfido =
         Onfido.builder().apiToken("token").unknownApiUrl(server.url("/").toString()).build();
 
-    InputStream inputStream = onfido.document.download("document id").content;
+    FileDownload download = onfido.document.download("document id");
 
     // Correct path
     RecordedRequest request = server.takeRequest();
     assertEquals("/documents/document%20id/download", request.getPath());
 
     // Correct response body
-    assertTrue(inputStream != null);
+    assertEquals("test", new String(download.content));
+    assertEquals("image/png", download.contentType);
   }
 
   @Test

--- a/onfido-java/src/test/java/com/onfido/integration/DocumentManagerTest.java
+++ b/onfido-java/src/test/java/com/onfido/integration/DocumentManagerTest.java
@@ -1,7 +1,6 @@
 package com.onfido.integration;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import com.onfido.JsonObject;
 import com.onfido.Onfido;

--- a/onfido-java/src/test/java/com/onfido/integration/LivePhotoManagerTest.java
+++ b/onfido-java/src/test/java/com/onfido/integration/LivePhotoManagerTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertNotNull;
 
 import com.onfido.JsonObject;
 import com.onfido.Onfido;
+import com.onfido.api.FileDownload;
 import com.onfido.exceptions.ApiException;
 import com.onfido.models.LivePhoto;
 import java.io.ByteArrayInputStream;
@@ -49,19 +50,20 @@ public class LivePhotoManagerTest extends ApiIntegrationTest {
 
   @Test
   public void downloadLivePhoto() throws Exception {
-    MockWebServer server = mockFileRequestResponse();
+    MockWebServer server = mockFileRequestResponse("test", "image/png");
 
     Onfido onfido =
         Onfido.builder().apiToken("token").unknownApiUrl(server.url("/").toString()).build();
 
-    InputStream inputStream = onfido.livePhoto.download("live photo id").content;
+    FileDownload download = onfido.livePhoto.download("live photo id");
 
     // Correct path
     RecordedRequest request = server.takeRequest();
     assertEquals("/live_photos/live%20photo%20id/download", request.getPath());
 
     // Correct response body
-    assertNotNull(inputStream);
+    assertEquals("test", new String(download.content));
+    assertEquals("image/png", download.contentType);
   }
 
   @Test

--- a/onfido-java/src/test/java/com/onfido/integration/LivePhotoManagerTest.java
+++ b/onfido-java/src/test/java/com/onfido/integration/LivePhotoManagerTest.java
@@ -1,7 +1,6 @@
 package com.onfido.integration;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 import com.onfido.JsonObject;
 import com.onfido.Onfido;

--- a/onfido-java/src/test/java/com/onfido/integration/LiveVideoManagerTest.java
+++ b/onfido-java/src/test/java/com/onfido/integration/LiveVideoManagerTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertNotNull;
 
 import com.onfido.JsonObject;
 import com.onfido.Onfido;
+import com.onfido.api.FileDownload;
 import com.onfido.exceptions.ApiException;
 import com.onfido.models.LiveVideo;
 import java.io.InputStream;
@@ -19,36 +20,38 @@ public class LiveVideoManagerTest extends ApiIntegrationTest {
 
   @Test
   public void downloadLiveVideo() throws Exception {
-    MockWebServer server = mockFileRequestResponse();
+    MockWebServer server = mockFileRequestResponse("test", "video/mp4");
 
     Onfido onfido =
         Onfido.builder().apiToken("token").unknownApiUrl(server.url("/").toString()).build();
 
-    InputStream inputStream = onfido.liveVideo.download("live video id").content;
+    FileDownload download = onfido.liveVideo.download("live video id");
 
     // Correct path
     RecordedRequest request = server.takeRequest();
     assertEquals("/live_videos/live%20video%20id/download", request.getPath());
 
     // Correct response body
-    assertNotNull(inputStream);
+    assertEquals("test", new String(download.content));
+    assertEquals("video/mp4", download.contentType);
   }
 
   @Test
   public void downloadLiveVideoFrame() throws Exception {
-    MockWebServer server = mockFileRequestResponse();
+    MockWebServer server = mockFileRequestResponse("test", "image/png");
 
     Onfido onfido =
         Onfido.builder().apiToken("token").unknownApiUrl(server.url("/").toString()).build();
 
-    InputStream inputStream = onfido.liveVideo.downloadFrame("live video id").content;
+    FileDownload download = onfido.liveVideo.downloadFrame("live video id");
 
     // Correct path
     RecordedRequest request = server.takeRequest();
     assertEquals("/live_videos/live%20video%20id/frame", request.getPath());
 
     // Correct response body
-    assertNotNull(inputStream);
+    assertEquals("test", new String(download.content));
+    assertEquals("image/png", download.contentType);
   }
 
   @Test

--- a/onfido-java/src/test/java/com/onfido/integration/LiveVideoManagerTest.java
+++ b/onfido-java/src/test/java/com/onfido/integration/LiveVideoManagerTest.java
@@ -1,14 +1,12 @@
 package com.onfido.integration;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 import com.onfido.JsonObject;
 import com.onfido.Onfido;
 import com.onfido.api.FileDownload;
 import com.onfido.exceptions.ApiException;
 import com.onfido.models.LiveVideo;
-import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
 import okhttp3.mockwebserver.MockWebServer;


### PR DESCRIPTION
## Description

We currently close the download stream before you can actually download the file. A fix for #25 

## Explanation

Return the download as a byte array rather than an input stream. This is simpler for users of the library and means they don't have to worry about closing the input stream themselves.

We've decided it's okay to load the full image into memory, because it's limited to 10mb. We may need to improve how live videos are downloaded in the future, however this has lower usage.

I've considered this not a breaking change, because it currently doesn't work anyway. It could cause a compile error if a client was already using it and updated, but in that case their code would be failing at runtime instead.

## Testing

Improved unit tests to check the actual content gets returned

Thanks @JakeBat for manually testing 👍 