### PR TITLE
Adds line1, line2, line3 fields to address object for ID Enhanced

### DIFF
--- a/onfido-java/src/main/models/address.json
+++ b/onfido-java/src/main/models/address.json
@@ -36,6 +36,18 @@
     "state": {
       "type": "string",
       "description": "The address state. US states must use the USPS abbreviation (see also ISO 3166-2:US), for example AK, CA, or TX."
+    },
+    "line1": {
+      "type": "string",
+      "description": "Line 1 of the address (ID Enhanced reports)."
+    },
+    "line2": {
+      "type": "string",
+      "description": "Line 2 of the address (ID Enhanced reports)."
+    },
+    "line3": {
+      "type": "string",
+      "description": "Line 3 of the address (ID Enhanced reports)."
     }
   }
 }


### PR DESCRIPTION
Library does not yet allow for line1, line2, line3 in address object, so this adds functionality

https://documentation.onfido.com/#address-object