### PR TITLE
Check class to allow `null` values for privacy consent parameter

### DIFF
--- a/generate-models-maven-plugin/src/main/java/com/onfido/models/Property.java
+++ b/generate-models-maven-plugin/src/main/java/com/onfido/models/Property.java
@@ -84,6 +84,8 @@ public final class Property {
     switch (propertyJson.type) {
       case "boolean":
         return TypeInfo.primitiveType("boolean", "Boolean", "false");
+      case "Boolean":
+        return TypeInfo.primitiveType("Boolean", "Boolean", "null");
       case "integer":
         return TypeInfo.primitiveType("int", "Integer", "0");
       case "object":

--- a/onfido-java/pom.xml
+++ b/onfido-java/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.onfido</groupId>
     <artifactId>onfido-api-java</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
 
     <name>Onfido API Java Client</name>
     <description>Official Java API client library for the Onfido API</description>

--- a/onfido-java/src/main/models/check.json
+++ b/onfido-java/src/main/models/check.json
@@ -99,7 +99,7 @@
       "description": "The list of report object ids associated with the check."
     },
     "privacy_notices_read_consent_given": {
-      "type": "boolean",
+      "type": "Boolean",
       "description": "Indicates that the privacy notices and terms of service have been read and, where specific laws require, that consent has been given for Onfido."
     },
     "webhook_ids": {


### PR DESCRIPTION
Change the type to `Boolean` for `privacy_notices_read_consent_given` in Check class to account for when no value is passed during check creation and the parameter is returned as `null` in the check response as per documentation.