### PR TITLE
Add the ability to specify proxy and the HttpClient read timeout.

### DIFF
--- a/onfido-java/src/main/java/com/onfido/Onfido.java
+++ b/onfido-java/src/main/java/com/onfido/Onfido.java
@@ -4,6 +4,9 @@ import com.onfido.api.Config;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 
+import java.net.Proxy;
+import java.time.Duration;
+
 /** The main class used for accessing instances of the manager classes. */
 public final class Onfido {
   private static final OkHttpClient CLIENT = new OkHttpClient();
@@ -38,14 +41,21 @@ public final class Onfido {
 
   private Onfido(Builder builder) {
     config = new Config(builder);
-    OkHttpClient client = CLIENT;
-    if (builder.hasClientAttributes()) {
-      OkHttpClient.Builder clientBuilder = CLIENT.newBuilder();
-      if (builder.clientInterceptor != null) {
-        clientBuilder.addInterceptor(builder.clientInterceptor);
-      }
-      client = clientBuilder.build();
+    OkHttpClient.Builder clientBuilder = CLIENT.newBuilder();
+
+    if (builder.clientInterceptor != null) {
+      clientBuilder.addInterceptor(builder.clientInterceptor);
     }
+
+    if (builder.httpClientReadTimeout != null) {
+      clientBuilder.readTimeout(builder.httpClientReadTimeout);
+    }
+
+    if (builder.httpClientProxy != null) {
+      clientBuilder.proxy(builder.httpClientProxy);
+    }
+
+    final OkHttpClient client = clientBuilder.build();
     applicant = new ApplicantManager(this.config, client);
     document = new DocumentManager(this.config, client);
     check = new CheckManager(this.config, client);
@@ -66,6 +76,10 @@ public final class Onfido {
     public String apiUrl = "";
     /** The HTTP client interceptor. */
     private Interceptor clientInterceptor;
+    /** Read timeout duration, defaults to 15 seconds. */
+    private Duration httpClientReadTimeout = Duration.ofSeconds(15);
+    /** HttpClient Proxy */
+    private Proxy httpClientProxy;
 
     private Builder() {}
 
@@ -113,6 +127,26 @@ public final class Onfido {
     }
 
     /**
+     * The read timeout duration that will be used to configure the HttpClient
+     * @param readTimeout the readTimeout
+     * @return the builder
+     */
+    public Builder clientReadTimeout(Duration readTimeout) {
+      this.httpClientReadTimeout = readTimeout;
+      return this;
+    }
+
+    /**
+     * The proxy that will be used to configure the HttpClient with
+     * @param proxy the proxy
+     * @return the proxy
+     */
+    public Builder clientProxy(Proxy proxy) {
+      this.httpClientProxy = proxy;
+      return this;
+    }
+
+    /**
      * Sets the object to use the EU region base URL.
      *
      * @return the builder
@@ -151,10 +185,6 @@ public final class Onfido {
     public Builder unknownApiUrl(String url) {
       this.apiUrl = url;
       return this;
-    }
-
-    private boolean hasClientAttributes() {
-      return clientInterceptor != null;
     }
   }
 

--- a/onfido-java/src/main/java/com/onfido/Onfido.java
+++ b/onfido-java/src/main/java/com/onfido/Onfido.java
@@ -76,8 +76,8 @@ public final class Onfido {
     public String apiUrl = "";
     /** The HTTP client interceptor. */
     private Interceptor clientInterceptor;
-    /** Read timeout duration, defaults to 15 seconds. */
-    private Duration httpClientReadTimeout = Duration.ofSeconds(15);
+    /** Read timeout duration, defaults to 30 seconds. */
+    private Duration httpClientReadTimeout = Duration.ofSeconds(30);
     /** HttpClient Proxy */
     private Proxy httpClientProxy;
 

--- a/onfido-java/src/test/java/com/onfido/integration/OnfidoIntegrationTest.java
+++ b/onfido-java/src/test/java/com/onfido/integration/OnfidoIntegrationTest.java
@@ -1,0 +1,75 @@
+package com.onfido.integration;
+
+import com.onfido.JsonObject;
+import com.onfido.Onfido;
+import com.onfido.exceptions.OnfidoException;
+import com.onfido.models.SdkToken;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.SocketPolicy;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.time.Duration;
+
+import static org.junit.Assert.assertEquals;
+
+public class OnfidoIntegrationTest {
+
+  private final MockWebServer mockWebServer = new MockWebServer();
+
+  @BeforeTest
+  public void beforeEach() throws Exception {
+    mockWebServer.start();
+  }
+
+  @AfterTest
+  public void afterEach() throws Exception {
+    mockWebServer.shutdown();
+  }
+
+  @Test(expectedExceptions = OnfidoException.class, timeOut = 1500L)
+  public void setClientReadTimeout() throws Exception {
+    String response = new JsonObject().add("token", "123").toJson();
+
+    Onfido onfido = Onfido.builder()
+            // Providing a 1 second read timeout
+            .clientReadTimeout(Duration.ofSeconds(1L))
+            .apiToken("token")
+            .unknownApiUrl(mockWebServer.url("/").toString())
+            .build();
+
+    final MockResponse mockResponse = new MockResponse().setBody(response);
+    mockResponse.socketPolicy(SocketPolicy.NO_RESPONSE);
+    mockWebServer.enqueue(mockResponse);
+
+    onfido.sdkToken.generate(SdkToken.request().applicantId("appId").referrer("refId"));
+  }
+
+  @Test
+  public void setClientProxy() throws Exception {
+    final MockWebServer proxyServer = new MockWebServer();
+
+    try {
+      proxyServer.start();
+
+      String proxyServerResponse = new JsonObject().add("token", "123").toJson();
+
+      Onfido onfido = Onfido.builder()
+              // Make Onfido point to the proxy server.
+              .clientProxy(proxyServer.toProxyAddress())
+              .apiToken("token")
+              .unknownApiUrl(mockWebServer.url("/").toString())
+              .build();
+
+      proxyServer.enqueue(new MockResponse().setBody(proxyServerResponse));
+
+      String response = onfido.sdkToken.generate(SdkToken.request().applicantId("appId").referrer("refId"));
+
+      assertEquals(response, "123");
+    } finally {
+      proxyServer.shutdown();
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the ability for the customers to set a read timeout (defaults to 15 seconds) to the underlying HttpClient, also adds the ability to use a java.net.Proxy as per customer request. 