### PR TITLE
Support for Driver's License Data Verification report

### DIFF
--- a/onfido-java/src/main/models/check.json
+++ b/onfido-java/src/main/models/check.json
@@ -121,6 +121,11 @@
       },
       "writeOnly": true,
       "description": "Triggers a pre-determined 'consider' report result in the sandbox for reports specified in the array."
+    },
+    "us_driving_licence": {
+      "$ref": "./driving_licence.json",
+      "description": "An object that contains all accepted fields for the Driver's License Data Verification report.",
+      "writeOnly": true
     }
   }
 }

--- a/onfido-java/src/main/models/driving_licence.json
+++ b/onfido-java/src/main/models/driving_licence.json
@@ -19,7 +19,7 @@
     },
     "city": {
       "type": "string",
-      "description": "Date of birth in yyyy-mm-dd format"
+      "description": "The city of the owner's address"
     },
     "date_of_birth": {
       "type": "string",
@@ -33,7 +33,7 @@
     "expiration_date": {
       "type": "string",
       "format": "date",
-      "description": "Date of birth in yyyy-mm-dd format"
+      "description": "Expiration date of the driving licence in yyyy-mm-dd format"
     },
     "eye_color_code": {
       "type": "string",
@@ -41,7 +41,7 @@
     },
     "first_name": {
       "type": "string",
-      "description": "The applicant’s first name"
+      "description": "The owner’s first name"
     },
     "gender": {
       "type": "string",
@@ -50,7 +50,7 @@
     },
     "height_measure_feet": {
       "type": "integer",
-      "description": "Height feet",
+      "description": "Height, feet",
       "readOnly": true
     },
     "height_measure_inches": {
@@ -69,7 +69,7 @@
     },
     "middle_name": {
       "type": "string",
-      "description": "The owner’s middle"
+      "description": "The owner’s middle name"
     },
     "name_suffix": {
       "type": "string",
@@ -81,7 +81,7 @@
     },
     "state": {
       "type": "string",
-      "description": "The address state. US states must use the USPS abbreviation, e.g. AK, CA, or TX."
+      "description": "The state of the owner's address. US states must use the USPS abbreviation, e.g. AK, CA, or TX."
     },
     "weight_measure": {
       "type": "integer",

--- a/onfido-java/src/main/models/driving_licence.json
+++ b/onfido-java/src/main/models/driving_licence.json
@@ -1,0 +1,91 @@
+{
+  "title": "DrivingLicence",
+  "properties": {
+    "id_number": {
+      "type": "string",
+      "description": "Driving licence ID number"
+    },
+    "state_code": {
+      "type": "string",
+      "description": "Two letter code of issuing state (state-issued driving licenses only)"
+    },
+    "address_line_1": {
+      "type": "string",
+      "description": "Line 1 of the address"
+    },
+    "address_line_2": {
+      "type": "string",
+      "description": "Line 2 of the address"
+    },
+    "city": {
+      "type": "string",
+      "description": "Date of birth in yyyy-mm-dd format"
+    },
+    "date_of_birth": {
+      "type": "string",
+      "format": "date",
+      "description": "Date of birth in yyyy-mm-dd format"
+    },
+    "document_category": {
+      "type": "string",
+      "description": "Document category. One of {\"driver license\", \"driver permit\", \"id card\"}"
+    },
+    "expiration_date": {
+      "type": "string",
+      "format": "date",
+      "description": "Date of birth in yyyy-mm-dd format"
+    },
+    "eye_color_code": {
+      "type": "string",
+      "description": "Eye color code. One of {\"BLK\", \"BLU\", \"BRO\", \"DIC\", \"GRY\", \"GRN\", \"HAZ\", \"MAR\", \"PNK\"}"
+    },
+    "first_name": {
+      "type": "string",
+      "description": "The applicant’s first name"
+    },
+    "gender": {
+      "type": "string",
+      "description": "Gender. Valid values are Male and Female.",
+      "readOnly": true
+    },
+    "height_measure_feet": {
+      "type": "integer",
+      "description": "Height feet",
+      "readOnly": true
+    },
+    "height_measure_inches": {
+      "type": "integer",
+      "description": "Height, inches",
+      "readOnly": true
+    },
+    "issue_date": {
+      "type": "string",
+      "format": "date",
+      "description": "Issue date in yyyy-mm-dd format"
+    },
+    "last_name": {
+      "type": "string",
+      "description": "The owner’s surname"
+    },
+    "middle_name": {
+      "type": "string",
+      "description": "The owner’s middle"
+    },
+    "name_suffix": {
+      "type": "string",
+      "description": "The owner’s name suffix"
+    },
+    "postal_code": {
+      "type": "string",
+      "description": "The postcode or ZIP of the owner’s address"
+    },
+    "state": {
+      "type": "string",
+      "description": "The address state. US states must use the USPS abbreviation, e.g. AK, CA, or TX."
+    },
+    "weight_measure": {
+      "type": "integer",
+      "description": "Weight in pounds"
+    }
+  }
+}

--- a/onfido-java/src/test/java/com/onfido/integration/CheckManagerTest.java
+++ b/onfido-java/src/test/java/com/onfido/integration/CheckManagerTest.java
@@ -8,6 +8,8 @@ import com.onfido.api.FileDownload;
 import com.onfido.models.Check;
 import java.util.Arrays;
 import java.util.List;
+
+import com.onfido.models.DrivingLicence;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.testng.annotations.Test;
@@ -103,6 +105,38 @@ public class CheckManagerTest extends ApiIntegrationTest {
     ArrayList<String> expectedConsiderArrayList = new ArrayList<>();
     expectedConsiderArrayList.add("identity_enhanced");
     assertEquals(expectedConsiderArrayList, jsonObject.get("consider"));
+
+    // Correct response body
+    assertEquals("id", check.getApplicantId());
+  }
+
+  @Test
+  public void createDrivingLicenceCheck() throws Exception {
+    String response =
+            new JsonObject()
+                    .add("applicant_id", "id")
+                    .toJson();
+
+    MockWebServer server = mockRequestResponse(response);
+
+    Onfido onfido =
+            Onfido.builder().apiToken("token").unknownApiUrl(server.url("/").toString()).build();
+
+    Check check =
+            onfido.check.create(Check.request()
+                    .applicantId("id")
+                    .reportNames("us_driving_licence")
+                    .usDrivingLicence(DrivingLicence.request().idNumber("12345").stateCode("GA"))
+            );
+
+    // Correct path
+    RecordedRequest request = server.takeRequest();
+    assertEquals("/checks/", request.getPath());
+
+    // Correct request body
+    String json = request.getBody().readUtf8();
+    JsonObject jsonObject = JsonObject.parse(json);
+    assertEquals("id", jsonObject.get("applicant_id"));
 
     // Correct response body
     assertEquals("id", check.getApplicantId());


### PR DESCRIPTION
The PR extends the Check.Request object to support [Driver's License Data Verification (DLDV) report](https://documentation.onfido.com/#drivers-license-data-verification-report). 

```java
    Check check =
            onfido.check.create(Check.request()
                    .applicantId("id")
                    .reportNames("us_driving_licence")
                    .usDrivingLicence(DrivingLicence.request().idNumber("12121212").stateCode("GA"))
            );
```
the json sent to Onfido will look like this:

```json
{
  "applicant_id":"id",
   "report_names":["us_driving_licence"],
   "us_driving_licence":{
      "id_number":"12121212",
      "issue_state":"GA"
  }
}
```

