### PR TITLE
Upgrade okhttp3 dependency

### DIFF
--- a/onfido-java/pom.xml
+++ b/onfido-java/pom.xml
@@ -4,7 +4,11 @@
 
     <groupId>com.onfido</groupId>
     <artifactId>onfido-api-java</artifactId>
+<<<<<<< HEAD
     <version>2.6.1</version>
+=======
+    <version>2.7.0</version>
+>>>>>>> 2f1d1d4 (Additional change in version)
 
     <name>Onfido API Java Client</name>
     <description>Official Java API client library for the Onfido API</description>
@@ -53,7 +57,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>4.2.2</version>
+            <version>4.9.2</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.moshi</groupId>
@@ -69,7 +73,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
-            <version>4.2.2</version>
+            <version>4.9.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/onfido-java/pom.xml
+++ b/onfido-java/pom.xml
@@ -4,11 +4,7 @@
 
     <groupId>com.onfido</groupId>
     <artifactId>onfido-api-java</artifactId>
-<<<<<<< HEAD
-    <version>2.6.1</version>
-=======
     <version>2.7.0</version>
->>>>>>> 2f1d1d4 (Additional change in version)
 
     <name>Onfido API Java Client</name>
     <description>Official Java API client library for the Onfido API</description>


### PR DESCRIPTION
Upgrade okhttp3 dependency to 4.9.2 (was 4.2.2) to address CVE-2021-0341.