### PR TITLE
Add information about library version into User-Agent header

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,9 +5,13 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+      - 'release/**'
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+      - 'release/**'
 
 jobs:
   build:

--- a/onfido-java/pom.xml
+++ b/onfido-java/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.onfido</groupId>
     <artifactId>onfido-api-java</artifactId>
-    <version>2.7.0</version>
+    <version>2.7.1</version>
 
     <name>Onfido API Java Client</name>
     <description>Official Java API client library for the Onfido API</description>
@@ -119,6 +119,17 @@
                     </execution>
                 </executions>
             </plugin>
+                <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -187,6 +198,17 @@
                             <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>
                             <stagingProgressTimeoutMinutes>10</stagingProgressTimeoutMinutes>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                                </manifest>
+                            </archive>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/onfido-java/src/main/java/com/onfido/api/ResourceManager.java
+++ b/onfido-java/src/main/java/com/onfido/api/ResourceManager.java
@@ -133,11 +133,12 @@ public abstract class ResourceManager {
   }
 
   private Request.Builder requestBuilder(String path) {
+    String version = getClass().getPackage().getImplementationVersion();
 
     return new Request.Builder()
         .url(config.getApiUrl() + basePath + path)
         .header("Authorization", "Token token=" + config.getApiToken())
-        .header("User-Agent", "OnfidoJava")
+        .header("User-Agent", "onfido-java/" + version)
         .header("Accept", "application/json");
   }
 


### PR DESCRIPTION
Changing User-Agent header provided at each request into `onfido-java/{version}` to make it similar to format used by other client libraries. It includes a change to CI to run checks also on branches with name starting with  `release/`.