### PR TITLE
Update okhttp3 version to 4.10.0 (was 4.9.2)

### DIFF
--- a/onfido-java/pom.xml
+++ b/onfido-java/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.moshi</groupId>
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This is to fix vulnerability CVE-2022-24329