### PR TITLE
Refactor Onfido client to use more java-like getters

### DIFF
--- a/onfido-java/src/main/java/com/onfido/Onfido.java
+++ b/onfido-java/src/main/java/com/onfido/Onfido.java
@@ -19,36 +19,33 @@ public final class Onfido {
   private static final String US_API_URL = "https://api.us.onfido.com/v3.6/";
   private static final String CA_API_URL = "https://api.ca.onfido.com/v3.6/";
 
-  /** The Configuration for the instance. */
-  public final Config config;
-
   /** The manager class for the Applicant resource. */
-  public final ApplicantManager applicant;
+  private final ApplicantManager applicant;
   /** The manager class for the Document resource. */
-  public final DocumentManager document;
+  private final DocumentManager document;
   /** The manager class for the Check resource. */
-  public final CheckManager check;
+  private final CheckManager check;
   /** The manager class for the Report resource. */
-  public final ReportManager report;
+  private final ReportManager report;
   /** The manager class for the Live photo resource. */
-  public final LivePhotoManager livePhoto;
+  private final LivePhotoManager livePhoto;
   /** The manager class for the Live video resource. */
-  public final LiveVideoManager liveVideo;
+  private final LiveVideoManager liveVideo;
   /** The manager class for the Motion capture resource. */
-  public final MotionCaptureManager motionCapture;
+  private final MotionCaptureManager motionCapture;
   /** The manager class for the Address resource */
-  public final AddressManager address;
+  private final AddressManager address;
   /** The manager class for the Sdk token resource. */
-  public final SdkTokenManager sdkToken;
+  private final SdkTokenManager sdkToken;
   /** The manager class for the Webhook resource. */
-  public final WebhookManager webhook;
+  private final WebhookManager webhook;
   /** The manager class for the Extraction resource. */
-  public final ExtractionManager extraction;
+  private final ExtractionManager extraction;
   /** The manager class for the WorkflowRun resource. */
-  public final WorkflowRunManager workflowRun;
+  private final WorkflowRunManager workflowRun;
 
   private Onfido(Builder builder) {
-    config = new Config(builder);
+    Config config = new Config(builder);
     OkHttpClient.Builder clientBuilder = CLIENT.newBuilder();
 
     if (builder.clientInterceptors != null) {
@@ -68,18 +65,18 @@ public final class Onfido {
     }
 
     final OkHttpClient client = clientBuilder.build();
-    applicant = new ApplicantManager(this.config, client);
-    document = new DocumentManager(this.config, client);
-    check = new CheckManager(this.config, client);
-    report = new ReportManager(this.config, client);
-    livePhoto = new LivePhotoManager(this.config, client);
-    liveVideo = new LiveVideoManager(this.config, client);
-    motionCapture = new MotionCaptureManager(this.config, client);
-    address = new AddressManager(this.config, client);
-    sdkToken = new SdkTokenManager(this.config, client);
-    webhook = new WebhookManager(this.config, client);
-    extraction = new ExtractionManager(this.config, client);
-    workflowRun = new WorkflowRunManager(this.config, client);
+    applicant = new ApplicantManager(config, client);
+    document = new DocumentManager(config, client);
+    check = new CheckManager(config, client);
+    report = new ReportManager(config, client);
+    livePhoto = new LivePhotoManager(config, client);
+    liveVideo = new LiveVideoManager(config, client);
+    motionCapture = new MotionCaptureManager(config, client);
+    address = new AddressManager(config, client);
+    sdkToken = new SdkTokenManager(config, client);
+    webhook = new WebhookManager(config, client);
+    extraction = new ExtractionManager(config, client);
+    workflowRun = new WorkflowRunManager(config, client);
   }
 
   /** The Builder for the Onfido object. */
@@ -239,6 +236,102 @@ public final class Onfido {
       this.x509TrustManager = x509TrustManager;
       return this;
     }
+  }
+
+  /**
+   * Accessor for applicant manager.
+   * @return Applicant Manager
+   */
+  public ApplicantManager getApplicantManager() {
+    return applicant;
+  }
+
+  /**
+   * Accessor for document manager.
+   * @return Document Manager
+   */
+  public DocumentManager getDocumentManager() {
+    return document;
+  }
+
+  /**
+   * Accessor for check manager.
+   * @return check Manager
+   */
+  public CheckManager getCheckManager() {
+    return check;
+  }
+
+  /**
+   * Accessor for report manager.
+   * @return Report Manager
+   */
+  public ReportManager getReportManager() {
+    return report;
+  }
+
+  /**
+   * Accessor for live photo manager.
+   * @return Live Photo Manager
+   */
+  public LivePhotoManager getLivePhotoManager() {
+    return livePhoto;
+  }
+
+  /**
+   * Accessor for live video manager.
+   * @return Live Video Manager
+   */
+  public LiveVideoManager getLiveVideoManager() {
+    return liveVideo;
+  }
+
+  /**
+   * Accessor for motion capture manager.
+   * @return Motion Capture Manager
+   */
+  public MotionCaptureManager getMotionCaptureManager() {
+    return motionCapture;
+  }
+
+  /**
+   * Accessor for address manager.
+   * @return Address Manager
+   */
+  public AddressManager getAddressManager() {
+    return address;
+  }
+
+  /**
+   * Accessor for SDK token manager.
+   * @return SDK Token Manager
+   */
+  public SdkTokenManager getSdkTokenManager() {
+    return sdkToken;
+  }
+
+  /**
+   * Accessor for webhook manager.
+   * @return Webhook Manager
+   */
+  public WebhookManager getWebhookManager() {
+    return webhook;
+  }
+
+  /**
+   * Accessor for extraction manager.
+   * @return Extraction Manager
+   */
+  public ExtractionManager getExtractionManager() {
+    return extraction;
+  }
+
+  /**
+   * Accessor for workflow run manager.
+   * @return WorkFlow Run Manager
+   */
+  public WorkflowRunManager getWorkflowRunManager() {
+    return workflowRun;
   }
 
   /**

--- a/onfido-java/src/test/java/com/onfido/integration/AddressManagerTest.java
+++ b/onfido-java/src/test/java/com/onfido/integration/AddressManagerTest.java
@@ -20,7 +20,7 @@ public class AddressManagerTest extends TestBase {
                                          new JsonObject().add("postcode", "S2 2DF").map,
                                          new JsonObject().add("postcode", "S2 2DF").map)));
 
-    List<Address> addresses = onfido.address.pick("S2 2DF");
+    List<Address> addresses = onfido.getAddressManager().pick("S2 2DF");
 
     takeRequest("/addresses/pick?postcode=S2%202DF");
 

--- a/onfido-java/src/test/java/com/onfido/integration/DocumentManagerTest.java
+++ b/onfido-java/src/test/java/com/onfido/integration/DocumentManagerTest.java
@@ -54,7 +54,7 @@ public class DocumentManagerTest extends TestBase {
   public void downloadDocumentTest() throws Exception {
     prepareMock("test", "image/png", 0);
 
-    FileDownload download = onfido.document.download(document.getId());
+    FileDownload download = onfido.getDocumentManager().download(document.getId());
 
     takeRequest("/documents/" + document.getId() + "/download");
 
@@ -67,7 +67,7 @@ public class DocumentManagerTest extends TestBase {
     prepareMock("error", null, 400);
 
     try {
-      onfido.document.download("document-id");
+      onfido.getDocumentManager().download("document-id");
       Assert.fail();
     } catch (ApiException ex) {
       takeRequest("/documents/document-id/download");
@@ -79,7 +79,7 @@ public class DocumentManagerTest extends TestBase {
   public void findDocumentTest() throws Exception {
     prepareMock(new JsonObject().add("file_name", document.getFileName()));
 
-    Document lookupDocument = onfido.document.find(document.getId());
+    Document lookupDocument = onfido.getDocumentManager().find(document.getId());
 
     takeRequest("/documents/" + document.getId());
 
@@ -96,7 +96,7 @@ public class DocumentManagerTest extends TestBase {
                         new JsonObject().add("file_name", "anotherFile.png").map,
                         new JsonObject().add("file_name", "file.png").map)));
 
-    List<Document> documents = onfido.document.list(applicant.getId()).stream()
+    List<Document> documents = onfido.getDocumentManager().list(applicant.getId()).stream()
                                               .sorted(Comparator.comparing(Document::getFileName))
                                               .collect(Collectors.toList());
 
@@ -113,7 +113,7 @@ public class DocumentManagerTest extends TestBase {
     InputStream inputStream = new ByteArrayInputStream("testing testing 1 2".getBytes());
 
     try {
-      onfido.document.upload(inputStream, "file.png", Document.request());
+      onfido.getDocumentManager().upload(inputStream, "file.png", Document.request());
       Assert.fail();
     } catch (ApiException ex) {
       takeRequest("/documents/");

--- a/onfido-java/src/test/java/com/onfido/integration/ExtractionManagerTest.java
+++ b/onfido-java/src/test/java/com/onfido/integration/ExtractionManagerTest.java
@@ -37,7 +37,7 @@ public class ExtractionManagerTest extends TestBase {
                                   .add("date_of_birth", "1976-03-11")
                                   .add("date_of_expiry", "2031-05-28")));
 
-    Extraction extraction = onfido.extraction.perform(document.getId());
+    Extraction extraction = onfido.getExtractionManager().perform(document.getId());
 
     takeRequest("/extractions/");
 
@@ -58,7 +58,7 @@ public class ExtractionManagerTest extends TestBase {
                                   .add("date_of_birth", null)
                                   .add("date_of_expiry", null)));
 
-    Extraction extraction = onfido.extraction.perform(document.getId());
+    Extraction extraction = onfido.getExtractionManager().perform(document.getId());
 
     takeRequest("/extractions/");
 
@@ -77,7 +77,7 @@ public class ExtractionManagerTest extends TestBase {
                                   .add("date_of_birth", "")
                                   .add("date_of_expiry", "")));
 
-    Extraction extraction = onfido.extraction.perform(document.getId());
+    Extraction extraction = onfido.getExtractionManager().perform(document.getId());
 
     takeRequest("/extractions/");
 
@@ -112,7 +112,7 @@ public class ExtractionManagerTest extends TestBase {
                                     .add("personal_number", "20-10563145-8")
                                     .add("place_of_birth", "San Francisco")));
 
-    Extraction extraction = onfido.extraction.perform(document.getId());
+    Extraction extraction = onfido.getExtractionManager().perform(document.getId());
 
     takeRequest("/extractions/");
 

--- a/onfido-java/src/test/java/com/onfido/integration/LivePhotoManagerTest.java
+++ b/onfido-java/src/test/java/com/onfido/integration/LivePhotoManagerTest.java
@@ -45,7 +45,7 @@ public class LivePhotoManagerTest extends TestBase {
     File file = new File("media/sample_photo.png");
     InputStream inputStream = new FileInputStream(file);
 
-    LivePhoto livePhoto = onfido.livePhoto.upload(inputStream, filename, livePhotoRequest);
+    LivePhoto livePhoto = onfido.getLivePhotoManager().upload(inputStream, filename, livePhotoRequest);
     takeRequest("/live_photos/");
 
     return livePhoto;
@@ -74,7 +74,7 @@ public class LivePhotoManagerTest extends TestBase {
   public void downloadLivePhotoTest() throws Exception {
     prepareMock("test", "image/png", 200);
 
-    FileDownload download = onfido.livePhoto.download(livePhoto.getId());
+    FileDownload download = onfido.getLivePhotoManager().download(livePhoto.getId());
 
     takeRequest("/live_photos/" + livePhoto.getId() + "/download");
 
@@ -87,7 +87,7 @@ public class LivePhotoManagerTest extends TestBase {
     prepareMock("error", "image/png", 404);
 
     try {
-      onfido.livePhoto.download("wrong-id");
+      onfido.getLivePhotoManager().download("wrong-id");
       Assert.fail();
     } catch (ApiException ex) {
       takeRequest("/live_photos/wrong-id/download");
@@ -100,7 +100,7 @@ public class LivePhotoManagerTest extends TestBase {
     prepareMock(new JsonObject().add("file_name", "file.png")
                                 .add("id", livePhoto.getId()));
 
-    LivePhoto lookupLivePhoto = onfido.livePhoto.find(livePhoto.getId());
+    LivePhoto lookupLivePhoto = onfido.getLivePhotoManager().find(livePhoto.getId());
 
     takeRequest("/live_photos/" + livePhoto.getId());
 
@@ -117,7 +117,7 @@ public class LivePhotoManagerTest extends TestBase {
                     new JsonObject().add("file_name", "anotherFile.png").map,
                     new JsonObject().add("file_name", "file.png").map)));
 
-    List<LivePhoto> livePhotos = onfido.livePhoto.list(applicant.getId()).stream()
+    List<LivePhoto> livePhotos = onfido.getLivePhotoManager().list(applicant.getId()).stream()
                                                  .sorted(Comparator.comparing(LivePhoto::getFileName))
                                                  .collect(Collectors.toList());
 
@@ -134,7 +134,7 @@ public class LivePhotoManagerTest extends TestBase {
     InputStream inputStream = new ByteArrayInputStream("testing testing 1 2".getBytes());
 
     try {
-      onfido.livePhoto.upload(inputStream, "file.png", LivePhoto.request());
+      onfido.getLivePhotoManager().upload(inputStream, "file.png", LivePhoto.request());
       Assert.fail();
     } catch (ApiException ex) {
       takeRequest("/live_photos/");

--- a/onfido-java/src/test/java/com/onfido/integration/LiveVideoManagerTest.java
+++ b/onfido-java/src/test/java/com/onfido/integration/LiveVideoManagerTest.java
@@ -29,7 +29,7 @@ public class LiveVideoManagerTest extends TestBase {
   public void downloadLiveVideoTest() throws Exception {
     prepareMock("test", "video/quicktime", 200);
 
-    FileDownload download = onfido.liveVideo.download(sampleLiveVideoId1);
+    FileDownload download = onfido.getLiveVideoManager().download(sampleLiveVideoId1);
 
     takeRequest("/live_videos/" + sampleLiveVideoId1 + "/download");
 
@@ -42,7 +42,7 @@ public class LiveVideoManagerTest extends TestBase {
     prepareMock("<[����JFIF��C...", "image/jpeg", 200);
 
     try {
-      FileDownload download = onfido.liveVideo.downloadFrame(sampleLiveVideoId1);
+      FileDownload download = onfido.getLiveVideoManager().downloadFrame(sampleLiveVideoId1);
       takeRequest("/live_videos/" + sampleLiveVideoId1 + "/frame");
 
       assertTrue(new String(download.content).contains("JFIF"));
@@ -59,7 +59,7 @@ public class LiveVideoManagerTest extends TestBase {
     prepareMock("error", "video/quicktime", 404);
 
     try {
-      onfido.liveVideo.download("wrong-id");
+      onfido.getLiveVideoManager().download("wrong-id");
       Assert.fail();
     } catch (ApiException ex) {
       takeRequest("/live_videos/wrong-id/download");
@@ -71,7 +71,7 @@ public class LiveVideoManagerTest extends TestBase {
   public void findLiveVideoTest() throws Exception {
     prepareMock(new JsonObject().add("file_name", "video.mov"));
 
-    LiveVideo liveVideo = onfido.liveVideo.find(sampleLiveVideoId1);
+    LiveVideo liveVideo = onfido.getLiveVideoManager().find(sampleLiveVideoId1);
 
     takeRequest("/live_videos/" + sampleLiveVideoId1);
 
@@ -85,7 +85,7 @@ public class LiveVideoManagerTest extends TestBase {
                                        new JsonObject().add("file_name", "video.mov").map,
                                        new JsonObject().add("file_name", "video.mov").map)));
 
-    List<LiveVideo> liveVideos = onfido.liveVideo.list(sampleApplicantId);
+    List<LiveVideo> liveVideos = onfido.getLiveVideoManager().list(sampleApplicantId);
 
     takeRequest("/live_videos/?applicant_id=" + sampleApplicantId);
 

--- a/onfido-java/src/test/java/com/onfido/integration/MotionCaptureManagerTest.java
+++ b/onfido-java/src/test/java/com/onfido/integration/MotionCaptureManagerTest.java
@@ -22,7 +22,7 @@ public class MotionCaptureManagerTest extends TestBase {
   public void downloadMotionCaptureTest() throws Exception {
     prepareMock("test", "video/mp4", 200);
 
-    FileDownload download = onfido.motionCapture.download(EXAMPLE_ID_1);
+    FileDownload download = onfido.getMotionCaptureManager().download(EXAMPLE_ID_1);
 
     takeRequest("/motion_captures/" + EXAMPLE_ID_1 + "/download");
 
@@ -35,7 +35,7 @@ public class MotionCaptureManagerTest extends TestBase {
     prepareMock("test", "image/jpeg", 200);
 
     try {
-      FileDownload download = onfido.motionCapture.downloadFrame(EXAMPLE_ID_1);
+      FileDownload download = onfido.getMotionCaptureManager().downloadFrame(EXAMPLE_ID_1);
       takeRequest("/motion_captures/" + EXAMPLE_ID_1 + "/frame");
 
       assertTrue(download.contentType.contains("image/jpeg"));
@@ -51,7 +51,7 @@ public class MotionCaptureManagerTest extends TestBase {
     prepareMock("error", "video/mp4", 404);
 
     try {
-      onfido.motionCapture.download(NON_EXISTING_ID);
+      onfido.getMotionCaptureManager().download(NON_EXISTING_ID);
       Assert.fail();
     } catch (ApiException ex) {
       takeRequest(String.format("/motion_captures/%s/download", NON_EXISTING_ID));
@@ -65,7 +65,7 @@ public class MotionCaptureManagerTest extends TestBase {
 
     prepareMock(new JsonObject().add("file_name", expectedFilename));
 
-    MotionCapture motionCapture = onfido.motionCapture.find(EXAMPLE_ID_1);
+    MotionCapture motionCapture = onfido.getMotionCaptureManager().find(EXAMPLE_ID_1);
 
     takeRequest("/motion_captures/" + EXAMPLE_ID_1);
     assertEquals(expectedFilename, motionCapture.getFileName());
@@ -78,7 +78,7 @@ public class MotionCaptureManagerTest extends TestBase {
                                        new JsonObject().add("id", "id-1").map,
                                        new JsonObject().add("id", "id-2").map)));
 
-    List<MotionCapture> motionCaptures = onfido.motionCapture.list(sampleApplicantId);
+    List<MotionCapture> motionCaptures = onfido.getMotionCaptureManager().list(sampleApplicantId);
 
     takeRequest("/motion_captures/?applicant_id=" + sampleApplicantId);
 

--- a/onfido-java/src/test/java/com/onfido/integration/ReportManagerTest.java
+++ b/onfido-java/src/test/java/com/onfido/integration/ReportManagerTest.java
@@ -36,7 +36,7 @@ public class ReportManagerTest extends TestBase {
 
   private Report findReport(String reportId, String mockedReportName) throws Exception {
     prepareMock(new JsonObject().add("name", mockedReportName));
-    Report report = onfido.report.find(reportId);
+    Report report = onfido.getReportManager().find(reportId);
     takeRequest("/reports/" + reportId);
 
     return report;
@@ -61,7 +61,7 @@ public class ReportManagerTest extends TestBase {
                             new JsonObject().add("name", "document").map,
                             new JsonObject().add("name", "identity_enhanced").map)));
 
-    List<Report> reports = onfido.report.list(check.getId()).stream()
+    List<Report> reports = onfido.getReportManager().list(check.getId()).stream()
                                         .sorted(Comparator.comparing(Report::getName))
                                         .collect(Collectors.toList());
 
@@ -76,7 +76,7 @@ public class ReportManagerTest extends TestBase {
     Report report = findReport(check.getReportIds().get(0), "document");
 
     prepareMock("", null, 204);
-    onfido.report.resume(report.getId());
+    onfido.getReportManager().resume(report.getId());
     takeRequest("/reports/" + report.getId() + "/resume");
   }
 
@@ -85,7 +85,7 @@ public class ReportManagerTest extends TestBase {
     Report report = findReport(check.getReportIds().get(0), "document");
 
     prepareMock("", null, 204);
-    onfido.report.cancel(report.getId());
+    onfido.getReportManager().cancel(report.getId());
     takeRequest("/reports/" + report.getId() + "/cancel");
   }
 }

--- a/onfido-java/src/test/java/com/onfido/integration/TestBase.java
+++ b/onfido-java/src/test/java/com/onfido/integration/TestBase.java
@@ -126,7 +126,7 @@ public class TestBase {
     File file = new File("media/sample_driving_licence.png");
     InputStream inputStream = new FileInputStream(file);
 
-    Document document = onfido.document.upload(inputStream, filename, documentRequest);
+    Document document = onfido.getDocumentManager().upload(inputStream, filename, documentRequest);
 
     takeRequest("/documents/");
 
@@ -196,8 +196,8 @@ public class TestBase {
       return;
     }
 
-    for (Webhook webhook : onfido.webhook.list()) {
-      onfido.webhook.delete(webhook.getId());
+    for (Webhook webhook : onfido.getWebhookManager().list()) {
+      onfido.getWebhookManager().delete(webhook.getId());
     }
   }
 

--- a/onfido-java/src/test/java/com/onfido/integration/WebhookManagerTest.java
+++ b/onfido-java/src/test/java/com/onfido/integration/WebhookManagerTest.java
@@ -37,7 +37,7 @@ public class WebhookManagerTest extends TestBase {
     prepareMock(new JsonObject().add("url", url)
                                 .add("id", UUID.randomUUID().toString()));
 
-    Webhook webhook = onfido.webhook.create(Webhook.request().url(url));
+    Webhook webhook = onfido.getWebhookManager().create(Webhook.request().url(url));
 
     takeRequest("/webhooks/");
 
@@ -55,7 +55,7 @@ public class WebhookManagerTest extends TestBase {
   public void findWebhookTest() throws Exception {
     prepareMock(new JsonObject().add("url", "https://example.com/webhook"));
 
-    Webhook lookupWebhook = onfido.webhook.find(webhook.getId());
+    Webhook lookupWebhook = onfido.getWebhookManager().find(webhook.getId());
 
     takeRequest("/webhooks/" + webhook.getId());
 
@@ -67,7 +67,7 @@ public class WebhookManagerTest extends TestBase {
     prepareMock(new JsonObject().add("url", "https://example.com/webhook/updated"));
 
     Webhook updatedWebhook =
-      onfido.webhook.update(webhook.getId(),
+      onfido.getWebhookManager().update(webhook.getId(),
                             Webhook.request().url("https://example.com/webhook/updated"));
 
     takeRequest("/webhooks/" + webhook.getId());
@@ -81,7 +81,7 @@ public class WebhookManagerTest extends TestBase {
   public void deleteWebhookTest() throws Exception {
     prepareMock("", null, 204);
 
-    onfido.webhook.delete(webhook.getId());
+    onfido.getWebhookManager().delete(webhook.getId());
 
     takeRequest("/webhooks/" + webhook.getId());
   }
@@ -97,7 +97,7 @@ public class WebhookManagerTest extends TestBase {
                                         new JsonObject().add("url", "https://example.com/secondWebhook").map,
                                         new JsonObject().add("url", "https://example.com/webhook").map)));
 
-    List<Webhook> webhooks = onfido.webhook.list().stream()
+    List<Webhook> webhooks = onfido.getWebhookManager().list().stream()
                                            .sorted(Comparator.comparing(Webhook::getUrl))
                                            .collect(Collectors.toList());
 

--- a/onfido-java/src/test/java/com/onfido/integration/WorkflowRunManagerTest.java
+++ b/onfido-java/src/test/java/com/onfido/integration/WorkflowRunManagerTest.java
@@ -38,7 +38,7 @@ public class WorkflowRunManagerTest extends TestBase {
                                 .add("applicant_id", applicantId)
                                 .add("id", UUID.randomUUID().toString()));
 
-    WorkflowRun workflowRun = onfido.workflowRun.create(WorkflowRun.request().workflowId(workflowId).applicantId(applicantId));
+    WorkflowRun workflowRun = onfido.getWorkflowRunManager().create(WorkflowRun.request().workflowId(workflowId).applicantId(applicantId));
 
     takeRequest("/workflow_runs/");
 
@@ -58,7 +58,7 @@ public class WorkflowRunManagerTest extends TestBase {
   public void findWorkflowRunTest() throws Exception {
     prepareMock(new JsonObject().add("workflow_id", WORKFLOW_ID).add("applicant_id", applicant.getId()));
 
-    WorkflowRun lookupWorkflowRun = onfido.workflowRun.find(workflowRun.getId());
+    WorkflowRun lookupWorkflowRun = onfido.getWorkflowRunManager().find(workflowRun.getId());
 
     takeRequest("/workflow_runs/" + workflowRun.getId());
 


### PR DESCRIPTION
Direct field access using `public` keyword makes it hard to mock this client whenever it is used. It requires a wrapper, adapter or more complex mocking libraries which may not be possible in all environments.