### PR TITLE
Add workflow run related evidence download endpoint

### DIFF
--- a/onfido-java/pom.xml
+++ b/onfido-java/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.onfido</groupId>
     <artifactId>onfido-api-java</artifactId>
-    <version>2.12.0</version>
+    <version>2.13.0</version>
 
     <name>Onfido API Java Client</name>
     <description>Official Java API client library for the Onfido API</description>

--- a/onfido-java/src/main/java/com/onfido/WorkflowRunManager.java
+++ b/onfido-java/src/main/java/com/onfido/WorkflowRunManager.java
@@ -7,6 +7,7 @@ import com.onfido.exceptions.OnfidoException;
 import com.onfido.models.WorkflowRun;
 import java.util.List;
 import okhttp3.OkHttpClient;
+import com.onfido.api.FileDownload;
 
 /**
  * Manager class for the WorkflowRun resource type. Contains resource-specific
@@ -44,14 +45,14 @@ public class WorkflowRunManager extends ResourceManager {
   }
 
   /**
-   * Retrieves a Workflow Run signed evidence file.
+   * Downloads a Workflow Run signed evidence file.
    *
    * @param workflowRunId the workflow run id
-   * @return byte array of the evidence file (PDF)
+   * @return the downloaded file as a FileDownload
    * @throws OnfidoException the onfido exception
    */
-  public byte[] evidence(String workflowRunId) throws OnfidoException {
-    return get(workflowRunId + "/signed_evidence_file").getBytes();
+  public FileDownload evidence(String workflowRunId) throws OnfidoException {
+    return downloadRequest(workflowRunId + "/signed_evidence_file");
   }
 
 }

--- a/onfido-java/src/main/java/com/onfido/WorkflowRunManager.java
+++ b/onfido-java/src/main/java/com/onfido/WorkflowRunManager.java
@@ -9,7 +9,8 @@ import java.util.List;
 import okhttp3.OkHttpClient;
 
 /**
- * Manager class for the WorkflowRun resource type. Contains resource-specific methods for interacting
+ * Manager class for the WorkflowRun resource type. Contains resource-specific
+ * methods for interacting
  * with the API.
  */
 public class WorkflowRunManager extends ResourceManager {
@@ -41,4 +42,16 @@ public class WorkflowRunManager extends ResourceManager {
   public WorkflowRun find(String workflowRunId) throws OnfidoException {
     return workflowRunParser.parse(get(workflowRunId));
   }
+
+  /**
+   * Retrieves a Workflow Run signed evidence file.
+   *
+   * @param workflowRunId the workflow run id
+   * @return byte array of the evidence file (PDF)
+   * @throws OnfidoException the onfido exception
+   */
+  public byte[] evidence(String workflowRunId) throws OnfidoException {
+    return get(workflowRunId + "/signed_evidence_file").getBytes();
+  }
+
 }

--- a/onfido-java/src/test/java/com/onfido/integration/WorkflowRunManagerTest.java
+++ b/onfido-java/src/test/java/com/onfido/integration/WorkflowRunManagerTest.java
@@ -1,12 +1,14 @@
 package com.onfido.integration;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.onfido.JsonObject;
 import com.onfido.Onfido;
 import com.onfido.models.WorkflowRun;
 import com.onfido.models.Applicant;
 import com.onfido.exceptions.OnfidoException;
+import com.onfido.api.FileDownload;
 
 import java.beans.Transient;
 import java.util.Arrays;
@@ -72,10 +74,11 @@ public class WorkflowRunManagerTest extends TestBase {
   public void evidenceWorkflowRunTest() throws Exception {
     prepareMock("PDF", "application/pdf", 200);
 
-    byte[] evidence = onfido.workflowRun.evidence(workflowRun.getId());
+    FileDownload download = onfido.workflowRun.evidence(workflowRun.getId());
 
     takeRequest("/workflow_runs/" + workflowRun.getId() + "/signed_evidence_file");
 
-    assertEquals(3, evidence.length);
+    assertEquals("application/pdf", download.contentType);
+    assertTrue(download.content.length > 0);
   }
 }

--- a/onfido-java/src/test/java/com/onfido/integration/WorkflowRunManagerTest.java
+++ b/onfido-java/src/test/java/com/onfido/integration/WorkflowRunManagerTest.java
@@ -70,12 +70,12 @@ public class WorkflowRunManagerTest extends TestBase {
 
   @Test
   public void evidenceWorkflowRunTest() throws Exception {
-    prepareMock(new JsonObject().add("workflow_id", WORKFLOW_ID).add("applicant_id", applicant.getId()));
+    prepareMock("PDF", "application/pdf", 200);
 
     byte[] evidence = onfido.workflowRun.evidence(workflowRun.getId());
 
     takeRequest("/workflow_runs/" + workflowRun.getId() + "/signed_evidence_file");
 
-    assertEquals(0, evidence.length);
+    assertEquals(3, evidence.length);
   }
 }

--- a/onfido-java/src/test/java/com/onfido/integration/WorkflowRunManagerTest.java
+++ b/onfido-java/src/test/java/com/onfido/integration/WorkflowRunManagerTest.java
@@ -8,6 +8,7 @@ import com.onfido.models.WorkflowRun;
 import com.onfido.models.Applicant;
 import com.onfido.exceptions.OnfidoException;
 
+import java.beans.Transient;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Comparator;
@@ -35,10 +36,11 @@ public class WorkflowRunManagerTest extends TestBase {
 
   private WorkflowRun createWorkflowRun(String workflowId, String applicantId) throws Exception {
     prepareMock(new JsonObject().add("workflow_id", workflowId)
-                                .add("applicant_id", applicantId)
-                                .add("id", UUID.randomUUID().toString()));
+        .add("applicant_id", applicantId)
+        .add("id", UUID.randomUUID().toString()));
 
-    WorkflowRun workflowRun = onfido.workflowRun.create(WorkflowRun.request().workflowId(workflowId).applicantId(applicantId));
+    WorkflowRun workflowRun = onfido.workflowRun
+        .create(WorkflowRun.request().workflowId(workflowId).applicantId(applicantId));
 
     takeRequest("/workflow_runs/");
 
@@ -64,5 +66,16 @@ public class WorkflowRunManagerTest extends TestBase {
 
     assertEquals(WORKFLOW_ID, lookupWorkflowRun.getWorkflowId());
     assertEquals(applicant.getId(), lookupWorkflowRun.getApplicantId());
+  }
+
+  @Test
+  public void evidenceWorkflowRunTest() throws Exception {
+    prepareMock(new JsonObject().add("workflow_id", WORKFLOW_ID).add("applicant_id", applicant.getId()));
+
+    byte[] evidence = onfido.workflowRun.evidence(workflowRun.getId());
+
+    takeRequest("/workflow_runs/" + workflowRun.getId() + "/signed_evidence_file");
+
+    assertEquals(0, evidence.length);
   }
 }


### PR DESCRIPTION
It adds a new [workflow run signed evidence PDF download endpoint](https://documentation.onfido.com/#retrieve-workflow-run-signed-evidence-file).