### PR TITLE
add Task resource to WebhookEvent, extend WebhookEventObject

### DIFF
--- a/generate-models-maven-plugin/src/main/java/com/onfido/models/Property.java
+++ b/generate-models-maven-plugin/src/main/java/com/onfido/models/Property.java
@@ -89,7 +89,7 @@ public final class Property {
       case "integer":
         return TypeInfo.primitiveType("int", "Integer", "0");
       case "object":
-        return TypeInfo.objectType("Map<String, Object>");
+        return TypeInfo.objectType("Object");
       case "array":
         return TypeInfo.listOf(typeInfoFor(propertyJson.items));
       case "string":

--- a/onfido-java/src/main/java/com/onfido/webhooks/WebhookEvent.java
+++ b/onfido-java/src/main/java/com/onfido/webhooks/WebhookEvent.java
@@ -1,5 +1,6 @@
 package com.onfido.webhooks;
 
+import com.onfido.models.Task;
 import com.squareup.moshi.Json;
 import java.util.Objects;
 
@@ -15,6 +16,9 @@ public class WebhookEvent {
   @Json(name = "object")
   private final WebhookEventObject object;
 
+  @Json(name = "resource")
+  private final Task resource;
+
   /**
    * Instantiates a new WebhookEvent.
    *
@@ -22,10 +26,11 @@ public class WebhookEvent {
    * @param action the action
    * @param object the object
    */
-  protected WebhookEvent(String resourceType, String action, WebhookEventObject object) {
+  protected WebhookEvent(String resourceType, String action, WebhookEventObject object, Task resource) {
     this.resourceType = resourceType;
     this.action = action;
     this.object = object;
+    this.resource = resource;
   }
 
   /**
@@ -55,6 +60,15 @@ public class WebhookEvent {
     return object;
   }
 
+  /**
+   * Gets the event resource.
+   *
+   * @return the Task
+   */
+  public Task getResource() {
+    return resource;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -66,7 +80,8 @@ public class WebhookEvent {
     WebhookEvent event = (WebhookEvent) o;
     return getResourceType().equals(event.getResourceType())
         && getAction().equals(event.getAction())
-        && getObject().equals(event.getObject());
+        && getObject().equals(event.getObject())
+        && ((getResource() == null && event.getResource() == null) || getResource().equals(event.getResource()));
   }
 
   @Override

--- a/onfido-java/src/main/java/com/onfido/webhooks/WebhookEventObject.java
+++ b/onfido-java/src/main/java/com/onfido/webhooks/WebhookEventObject.java
@@ -12,6 +12,15 @@ public class WebhookEventObject {
   @Json(name = "status")
   private final String status;
 
+  @Json(name = "task_spec_id")
+  private final String taskSpecId;
+
+  @Json(name = "task_def_id")
+  private final String taskDefId;
+
+  @Json(name = "workflow_run_id")
+  private final String workflowRunId;
+
   @Json(name = "href")
   private final String href;
 
@@ -23,12 +32,25 @@ public class WebhookEventObject {
    *
    * @param id the id
    * @param status the status
+   * @param taskSpecId the taskSpecId
+   * @param taskDefId the taskDefId
+   * @param workflowRunId the workflowRunId
    * @param href the href
    * @param completedAtIso8601 the completed at iso 8601
    */
-  protected WebhookEventObject(String id, String status, String href, String completedAtIso8601) {
+  protected WebhookEventObject(
+      String id,
+      String status,
+      String taskSpecId,
+      String taskDefId,
+      String workflowRunId,
+      String href,
+      String completedAtIso8601) {
     this.id = id;
     this.status = status;
+    this.taskSpecId = taskSpecId;
+    this.taskDefId = taskDefId;
+    this.workflowRunId = workflowRunId;
     this.href = href;
     this.completedAtIso8601 = completedAtIso8601;
   }
@@ -49,6 +71,33 @@ public class WebhookEventObject {
    */
   public String getStatus() {
     return status;
+  }
+
+  /**
+   * Gets taskSpecId.
+   *
+   * @return the taskSpecId
+   */
+  public String getTaskSpecId() {
+    return taskSpecId;
+  }
+
+  /**
+   * Gets taskDefId.
+   *
+   * @return the taskDefId.
+   */
+  public String getTaskDefId() {
+    return taskDefId;
+  }
+
+  /**
+   * get workflowRunId.
+   *
+   * @return the workflowRunId
+   */
+  public String getWorkflowRunId() {
+    return workflowRunId;
   }
 
   /**

--- a/onfido-java/src/main/models/task.json
+++ b/onfido-java/src/main/models/task.json
@@ -39,6 +39,19 @@
       "type": "object",
       "description": "Output data associated with the task",
       "readOnly": true
+    },
+    "status": {
+      "type": "string",
+      "description": "Status of the task",
+      "readOnly": true
+    },
+    "reasons": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Reasons of the task",
+      "readOnly": true
     }
   }
 }

--- a/onfido-java/src/test/java/com/onfido/webhooks/WebhookEventVerifierTest.java
+++ b/onfido-java/src/test/java/com/onfido/webhooks/WebhookEventVerifierTest.java
@@ -20,10 +20,13 @@ public class WebhookEventVerifierTest {
         new WebhookEventObject(
             "check-123",
             "complete",
+            "profile_4f4b2",
+            "profile",
+            "e25b19f5-a96e-4c15-8f80-fb6cad1a1ce5",
             "https://api.onfido.com/v3/checks/check-123",
             "2020-01-01T00:00:00Z");
 
-    expectedEvent = new WebhookEvent("check", "check.completed", object);
+    expectedEvent = new WebhookEvent("check", "check.completed", object, null);
   }
 
   @Test


### PR DESCRIPTION
In order to be able to get task object (called resource) from the webhooks, I extended the WebhookEvent.
Also, some missing properties on the WebhookEventObject were added.

`object` properties were erroneously parsed to `Map<String, Object>` before, causing parsing issues when querying certain tasks.