### PR TITLE
Upgrade okhttp3 dependency to 4.12.0 (was 4.10.0)

### DIFF
--- a/onfido-java/pom.xml
+++ b/onfido-java/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>4.10.0</version>
+            <version>4.12.0</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.moshi</groupId>
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
-            <version>4.10.0</version>
+            <version>4.12.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Upgrade okhttp3 dependency to 4.12.0 (was 4.10.0) to address [CVE-2023-3635](https://devhub.checkmarx.com/cve-details/CVE-2023-3635/).