### PR TITLE
Add tests focusing on Report schemas and workflow run outputs

### DIFF
--- a/src/test/java/com/onfido/integration/CheckTest.java
+++ b/src/test/java/com/onfido/integration/CheckTest.java
@@ -67,9 +67,8 @@ public class CheckTest extends TestBase {
             applicant,
             document,
             new CheckBuilder()
-                .reportNames(Arrays.asList(ReportName.DOCUMENT))
+                .reportNames(Arrays.asList(ReportName.DOCUMENT, ReportName.IDENTITY_ENHANCED))
                 .consider(Arrays.asList(ReportName.IDENTITY_ENHANCED))
-                .reportNames(Arrays.asList(ReportName.US_DRIVING_LICENCE))
                 .usDrivingLicence(new UsDrivingLicenceBuilder().idNumber("12345").state("GA")));
 
     Assertions.assertEquals(applicant.getId(), check.getApplicantId());

--- a/src/test/java/com/onfido/integration/LivePhotoTest.java
+++ b/src/test/java/com/onfido/integration/LivePhotoTest.java
@@ -22,10 +22,6 @@ public class LivePhotoTest extends TestBase {
     livePhoto = uploadLivePhoto(applicant, "sample_photo.png");
   }
 
-  private LivePhoto uploadLivePhoto(Applicant applicant, String filename) throws Exception {
-    return onfido.uploadLivePhoto(applicant.getId(), new File("media/" + filename), true);
-  }
-
   @Test
   public void uploadLivePhotoTest() throws Exception {
     Assertions.assertEquals("sample_photo.png", livePhoto.getFileName());

--- a/src/test/java/com/onfido/integration/ReportSchemasTest.java
+++ b/src/test/java/com/onfido/integration/ReportSchemasTest.java
@@ -1,14 +1,12 @@
 package com.onfido.integration;
 
+import static com.onfido.model.ReportStatus.COMPLETE;
+
 import com.onfido.model.*;
-
 import java.util.*;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import static com.onfido.model.ReportStatus.COMPLETE;
 
 public class ReportSchemasTest extends TestBase {
   private Applicant applicant;

--- a/src/test/java/com/onfido/integration/ReportSchemasTest.java
+++ b/src/test/java/com/onfido/integration/ReportSchemasTest.java
@@ -1,0 +1,70 @@
+package com.onfido.integration;
+
+import com.onfido.model.*;
+
+import java.util.*;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.onfido.model.ReportStatus.COMPLETE;
+
+public class ReportSchemasTest extends TestBase {
+  private Applicant applicant;
+  private Document document;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    applicant = createApplicant();
+    document = uploadDocument(applicant, "sample_driving_licence.png", "driving_licence");
+  }
+
+  @Test
+  public void schemaOfDocumentReportIsValid() throws Exception {
+    Check check =
+        createCheck(
+            applicant,
+            document,
+            new CheckBuilder().reportNames(Arrays.asList(ReportName.DOCUMENT)));
+
+    DocumentReport documentReport =
+        onfido.findReport(check.getReportIds().get(0)).getDocumentReport();
+
+    int iteration = 0;
+    while (!documentReport.getStatus().equals(COMPLETE)) {
+      if (iteration > 10) {
+        Assertions.fail("Report did not complete in time");
+      }
+      iteration += 1;
+      Thread.sleep(1000);
+      documentReport = onfido.findReport(check.getReportIds().get(0)).getDocumentReport();
+    }
+  }
+
+  @Test
+  public void schemaOfFacialSimilarityPhotoReportIsValid() throws Exception {
+    uploadLivePhoto(applicant, "sample_photo.png");
+
+    Check check =
+        createCheck(
+            applicant,
+            document,
+            new CheckBuilder()
+                .reportNames(Arrays.asList(ReportName.FACIAL_SIMILARITY_PHOTO_FULLY_AUTO)));
+
+    FacialSimilarityPhotoFullyAutoReport facialSimilarityPhotoFullyAutoReport =
+        onfido.findReport(check.getReportIds().get(0)).getFacialSimilarityPhotoFullyAutoReport();
+
+    int iteration = 0;
+    while (!facialSimilarityPhotoFullyAutoReport.getStatus().equals(COMPLETE)) {
+      if (iteration > 10) {
+        Assertions.fail("Report did not complete in time");
+      }
+      iteration += 1;
+      Thread.sleep(1000);
+      facialSimilarityPhotoFullyAutoReport =
+          onfido.findReport(check.getReportIds().get(0)).getFacialSimilarityPhotoFullyAutoReport();
+    }
+  }
+}

--- a/src/test/java/com/onfido/integration/ReportTest.java
+++ b/src/test/java/com/onfido/integration/ReportTest.java
@@ -34,7 +34,8 @@ public class ReportTest extends TestBase {
         createCheck(
             applicant,
             document,
-            new CheckBuilder().reportNames(Arrays.asList(ReportName.DOCUMENT)));
+            new CheckBuilder()
+                .reportNames(Arrays.asList(ReportName.DOCUMENT, ReportName.IDENTITY_ENHANCED)));
   }
 
   private List<Report> sortReports(List<Report> reports) {

--- a/src/test/java/com/onfido/integration/TasksTest.java
+++ b/src/test/java/com/onfido/integration/TasksTest.java
@@ -3,12 +3,10 @@ package com.onfido.integration;
 import com.onfido.model.Applicant;
 import com.onfido.model.CompleteTaskRequest;
 import com.onfido.model.Task;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/onfido/integration/TasksTest.java
+++ b/src/test/java/com/onfido/integration/TasksTest.java
@@ -1,0 +1,64 @@
+package com.onfido.integration;
+
+import com.onfido.model.Applicant;
+import com.onfido.model.CompleteTaskRequest;
+import com.onfido.model.Task;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TasksTest extends TestBase {
+  private UUID workflowRunId;
+
+  static final UUID WORKFLOW_ID = UUID.fromString("e8c921eb-0495-44fe-b655-bcdcaffdafe5");
+
+  @BeforeEach
+  public void setup() throws Exception {
+    Applicant applicant = createApplicant();
+    workflowRunId = createWorkflowRun(WORKFLOW_ID, applicant.getId()).getId();
+  }
+
+  @Test
+  public void listTasks() throws Exception {
+    List<Task> tasks = onfido.listTasks(workflowRunId);
+
+    Assertions.assertEquals(2, tasks.size());
+  }
+
+  @Test
+  public void findTask() throws Exception {
+    Task lookupTask = onfido.listTasks(workflowRunId).get(0);
+
+    Task task = onfido.findTask(workflowRunId, lookupTask.getId());
+
+    Assertions.assertEquals(lookupTask.getId(), task.getId());
+    Assertions.assertEquals(lookupTask.getTaskDefId(), task.getTaskDefId());
+  }
+
+  @Test
+  public void completeTask() throws Exception {
+    String taskId = getTaskIdByPartialId(workflowRunId, "profile");
+
+    Map<String, String> completeTaskBody = new HashMap<>();
+    completeTaskBody.put("first_name", "First");
+    completeTaskBody.put("last_name", "Last");
+
+    CompleteTaskRequest completeTaskRequest = new CompleteTaskRequest();
+    completeTaskRequest.setData(completeTaskBody);
+
+    onfido.completeTask(workflowRunId, taskId, completeTaskRequest);
+
+    Task completedTask = onfido.findTask(workflowRunId, taskId);
+    Map<String, String> taskOutput =
+        (Map<String, String>) completedTask.getAdditionalProperties().get("output");
+
+    Assertions.assertEquals("First", taskOutput.get("first_name"));
+    Assertions.assertEquals("Last", taskOutput.get("last_name"));
+  }
+}

--- a/src/test/java/com/onfido/integration/TestBase.java
+++ b/src/test/java/com/onfido/integration/TestBase.java
@@ -9,9 +9,12 @@ import com.onfido.model.Check;
 import com.onfido.model.CheckBuilder;
 import com.onfido.model.CountryCodes;
 import com.onfido.model.Document;
+import com.onfido.model.LivePhoto;
 import com.onfido.model.LocationBuilder;
 import com.onfido.model.ReportName;
 import com.onfido.model.Webhook;
+import com.onfido.model.WorkflowRun;
+import com.onfido.model.WorkflowRunBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
@@ -43,7 +46,7 @@ public class TestBase {
   }
 
   @AfterAll
-  private void tearDownAndCleanUp() throws IOException, ApiException {
+  public void tearDownAndCleanUp() throws IOException, ApiException {
     cleanUpApplicants();
     cleanUpWebhooks();
   }
@@ -85,6 +88,10 @@ public class TestBase {
         locationBuilder);
   }
 
+  protected LivePhoto uploadLivePhoto(Applicant applicant, String filename) throws Exception {
+    return onfido.uploadLivePhoto(applicant.getId(), new File("media/" + filename), true);
+  }
+
   protected Check createCheck(Applicant applicant, Document document, CheckBuilder checkBuilder)
       throws IOException, InterruptedException, ApiException {
     return onfido.createCheck(
@@ -92,6 +99,11 @@ public class TestBase {
             .applicantId(applicant.getId())
             .reportNames(Arrays.asList(ReportName.DOCUMENT, ReportName.IDENTITY_ENHANCED))
             .documentIds(Arrays.asList(document.getId())));
+  }
+
+  protected WorkflowRun createWorkflowRun(UUID workflowId, UUID applicantId) throws Exception {
+    return onfido.createWorkflowRun(
+            new WorkflowRunBuilder().workflowId(workflowId).applicantId(applicantId));
   }
 
   private boolean isAValidUuid(UUID uuid) {

--- a/src/test/java/com/onfido/integration/TestBase.java
+++ b/src/test/java/com/onfido/integration/TestBase.java
@@ -19,6 +19,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.UUID;
+import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
@@ -103,7 +105,7 @@ public class TestBase {
 
   protected WorkflowRun createWorkflowRun(UUID workflowId, UUID applicantId) throws Exception {
     return onfido.createWorkflowRun(
-            new WorkflowRunBuilder().workflowId(workflowId).applicantId(applicantId));
+        new WorkflowRunBuilder().workflowId(workflowId).applicantId(applicantId));
   }
 
   private boolean isAValidUuid(UUID uuid) {
@@ -131,5 +133,13 @@ public class TestBase {
     for (Webhook webhook : onfido.listWebhooks().getWebhooks()) {
       onfido.deleteWebhook(webhook.getId());
     }
+  }
+
+  public String getTaskIdByPartialId(UUID workflowRunId, String partialId) throws ApiException {
+    return onfido.listTasks(workflowRunId).stream()
+        .filter((task) -> task.getTaskDefId().contains(partialId))
+        .collect(Collectors.toList())
+        .get(0)
+        .getId();
   }
 }

--- a/src/test/java/com/onfido/integration/TestBase.java
+++ b/src/test/java/com/onfido/integration/TestBase.java
@@ -99,7 +99,6 @@ public class TestBase {
     return onfido.createCheck(
         checkBuilder
             .applicantId(applicant.getId())
-            .reportNames(Arrays.asList(ReportName.DOCUMENT, ReportName.IDENTITY_ENHANCED))
             .documentIds(Arrays.asList(document.getId())));
   }
 

--- a/src/test/java/com/onfido/integration/TestBase.java
+++ b/src/test/java/com/onfido/integration/TestBase.java
@@ -11,7 +11,6 @@ import com.onfido.model.CountryCodes;
 import com.onfido.model.Document;
 import com.onfido.model.LivePhoto;
 import com.onfido.model.LocationBuilder;
-import com.onfido.model.ReportName;
 import com.onfido.model.Webhook;
 import com.onfido.model.WorkflowRun;
 import com.onfido.model.WorkflowRunBuilder;
@@ -20,7 +19,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.UUID;
 import java.util.stream.Collectors;
-
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
@@ -97,9 +95,7 @@ public class TestBase {
   protected Check createCheck(Applicant applicant, Document document, CheckBuilder checkBuilder)
       throws IOException, InterruptedException, ApiException {
     return onfido.createCheck(
-        checkBuilder
-            .applicantId(applicant.getId())
-            .documentIds(Arrays.asList(document.getId())));
+        checkBuilder.applicantId(applicant.getId()).documentIds(Arrays.asList(document.getId())));
   }
 
   protected WorkflowRun createWorkflowRun(UUID workflowId, UUID applicantId) throws Exception {

--- a/src/test/java/com/onfido/integration/WorkflowRunOutputsTest.java
+++ b/src/test/java/com/onfido/integration/WorkflowRunOutputsTest.java
@@ -1,5 +1,6 @@
 package com.onfido.integration;
 
+import static com.onfido.model.WorkflowRun.StatusEnum.APPROVED;
 import static com.onfido.model.WorkflowRun.StatusEnum.PROCESSING;
 
 import com.google.gson.Gson;
@@ -89,6 +90,7 @@ public class WorkflowRunOutputsTest extends TestBase {
       workflowRun = onfido.findWorkflowRun(workflowRunId);
     }
 
+    Assertions.assertEquals(APPROVED, workflowRun.getStatus());
     Map<String, Map<String, Object>> workflowRunOutput =
         (Map<String, Map<String, Object>>) workflowRun.getOutput();
 

--- a/src/test/java/com/onfido/integration/WorkflowRunOutputsTest.java
+++ b/src/test/java/com/onfido/integration/WorkflowRunOutputsTest.java
@@ -1,17 +1,15 @@
 package com.onfido.integration;
 
+import static com.onfido.model.WorkflowRun.StatusEnum.PROCESSING;
+
 import com.google.gson.Gson;
 import com.onfido.model.*;
-
 import java.io.FileReader;
 import java.io.Reader;
 import java.util.*;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import static com.onfido.model.WorkflowRun.StatusEnum.PROCESSING;
 
 public class WorkflowRunOutputsTest extends TestBase {
   private Applicant applicant;

--- a/src/test/java/com/onfido/integration/WorkflowRunOutputsTest.java
+++ b/src/test/java/com/onfido/integration/WorkflowRunOutputsTest.java
@@ -1,0 +1,116 @@
+package com.onfido.integration;
+
+import com.google.gson.Gson;
+import com.onfido.model.*;
+
+import java.io.FileReader;
+import java.io.Reader;
+import java.util.*;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.onfido.model.WorkflowRun.StatusEnum.PROCESSING;
+
+public class WorkflowRunOutputsTest extends TestBase {
+  private Applicant applicant;
+  private final Gson gson = new Gson();
+
+  @BeforeEach
+  public void setup() throws Exception {
+    applicant = createApplicant();
+  }
+
+  @Test
+  public void profileDataCaptureAsOutput() throws Exception {
+    UUID workflowId = UUID.fromString("d27e510b-27a8-44c3-a3cc-bf4c0648a4ba");
+    UUID workflowRunId = createWorkflowRun(workflowId, applicant.getId()).getId();
+
+    String taskId = getTaskIdByPartialId(workflowRunId, "profile");
+
+    Reader reader = new FileReader("src/test/java/com/onfido/utils/ProfileDataCapture.json");
+    CompleteTaskRequest completeTaskRequest = gson.fromJson(reader, CompleteTaskRequest.class);
+
+    onfido.completeTask(workflowRunId, taskId, completeTaskRequest);
+    WorkflowRun workflowRun = onfido.findWorkflowRun(workflowRunId);
+
+    Map<String, Object> output = (Map<String, Object>) workflowRun.getOutput();
+    Assertions.assertEquals(completeTaskRequest.getData(), output.get("profile_capture_data"));
+  }
+
+  @Test
+  public void documentAndFacialSimilarityReportsAsOutputs() throws Exception {
+    UUID workflowId = UUID.fromString("5025d9fd-7842-4805-bce1-a7bfd7131b4e");
+    UUID workflowRunId = createWorkflowRun(workflowId, applicant.getId()).getId();
+
+    String profileDataTaskId = getTaskIdByPartialId(workflowRunId, "profile");
+
+    Map<String, String> completeProfileDataTaskBody = new HashMap<>();
+    completeProfileDataTaskBody.put("first_name", "First");
+    completeProfileDataTaskBody.put("last_name", "Last");
+
+    CompleteTaskRequest completeProfileDataTaskRequest = new CompleteTaskRequest();
+    completeProfileDataTaskRequest.setData(completeProfileDataTaskBody);
+    onfido.completeTask(workflowRunId, profileDataTaskId, completeProfileDataTaskRequest);
+
+    String documentCaptureTaskId = getTaskIdByPartialId(workflowRunId, "document_photo");
+    Document document = uploadDocument(applicant, "sample_driving_licence.png", "driving_licence");
+
+    Map<String, String> completeDocumentCaptureTaskBody = new HashMap<>();
+    List<Object> completeDocumentCaptureTaskBodyArray = new ArrayList<>();
+    CompleteTaskRequest completeDocumentCaptureTaskRequest = new CompleteTaskRequest();
+
+    completeDocumentCaptureTaskBody.put("id", document.getId().toString());
+    completeDocumentCaptureTaskBodyArray.add(completeDocumentCaptureTaskBody);
+    completeDocumentCaptureTaskRequest.setData(completeDocumentCaptureTaskBodyArray);
+    onfido.completeTask(workflowRunId, documentCaptureTaskId, completeDocumentCaptureTaskRequest);
+
+    String photoCaptureTaskId = getTaskIdByPartialId(workflowRunId, "face_photo");
+    LivePhoto livePhoto = uploadLivePhoto(applicant, "sample_photo.png");
+
+    Map<String, String> completeLivePhotoCaptureTaskBody = new HashMap<>();
+    List<Object> completeLivePhotoCaptureTaskBodyArray = new ArrayList<>();
+    CompleteTaskRequest completeLivePhotoCaptureTaskRequest = new CompleteTaskRequest();
+
+    completeLivePhotoCaptureTaskBody.put("id", livePhoto.getId().toString());
+    completeLivePhotoCaptureTaskBodyArray.add(completeLivePhotoCaptureTaskBody);
+    completeLivePhotoCaptureTaskRequest.setData(completeLivePhotoCaptureTaskBodyArray);
+    onfido.completeTask(workflowRunId, photoCaptureTaskId, completeLivePhotoCaptureTaskRequest);
+
+    WorkflowRun workflowRun = onfido.findWorkflowRun(workflowRunId);
+
+    // wait for workflow run to finish
+    int iteration = 0;
+    while (workflowRun.getStatus().equals(PROCESSING)) {
+      if (iteration > 10) {
+        Assertions.fail("Workflow run did not complete in time");
+      }
+      iteration += 1;
+      Thread.sleep(1000);
+      workflowRun = onfido.findWorkflowRun(workflowRunId);
+    }
+
+    Map<String, Map<String, Object>> workflowRunOutput =
+        (Map<String, Map<String, Object>>) workflowRun.getOutput();
+
+    // workflow run has configured as output the result of the document
+    // report `doc` and the facial similarity report `selfie`
+    String outputDocumentReport = gson.toJson(workflowRunOutput.get("doc"));
+    String outputFacialSimilarityReport = gson.toJson(workflowRunOutput.get("selfie"));
+
+    Assertions.assertTrue(outputDocumentReport.contains("breakdown"));
+    Assertions.assertTrue(outputDocumentReport.contains("properties"));
+    Assertions.assertTrue(outputDocumentReport.contains("repeat_attempts"));
+    Assertions.assertTrue(outputDocumentReport.contains("result"));
+    Assertions.assertTrue(outputDocumentReport.contains("status"));
+    Assertions.assertTrue(outputDocumentReport.contains("sub_result"));
+    Assertions.assertTrue(outputDocumentReport.contains("uuid"));
+
+    Assertions.assertTrue(outputFacialSimilarityReport.contains("breakdown"));
+    Assertions.assertTrue(outputFacialSimilarityReport.contains("properties"));
+    Assertions.assertTrue(outputFacialSimilarityReport.contains("result"));
+    Assertions.assertTrue(outputFacialSimilarityReport.contains("status"));
+    Assertions.assertTrue(outputFacialSimilarityReport.contains("uuid"));
+  }
+}

--- a/src/test/java/com/onfido/integration/WorkflowRunTest.java
+++ b/src/test/java/com/onfido/integration/WorkflowRunTest.java
@@ -2,7 +2,6 @@ package com.onfido.integration;
 
 import com.onfido.model.Applicant;
 import com.onfido.model.WorkflowRun;
-import com.onfido.model.WorkflowRunBuilder;
 import java.io.File;
 import java.nio.file.Files;
 import java.util.UUID;
@@ -20,11 +19,6 @@ public class WorkflowRunTest extends TestBase {
   public void setup() throws Exception {
     applicant = createApplicant();
     workflowRun = createWorkflowRun(WORKFLOW_ID, applicant.getId());
-  }
-
-  private WorkflowRun createWorkflowRun(UUID workflowId, UUID applicantId) throws Exception {
-    return onfido.createWorkflowRun(
-        new WorkflowRunBuilder().workflowId(workflowId).applicantId(applicantId));
   }
 
   @Test

--- a/src/test/java/com/onfido/utils/ProfileDataCapture.json
+++ b/src/test/java/com/onfido/utils/ProfileDataCapture.json
@@ -1,0 +1,20 @@
+{
+  "data": {
+    "country_residence": "GBR",
+    "first_name": "First",
+    "last_name": "Last",
+    "dob": "2000-01-01",
+    "email": "first.last@gmail.com",
+    "phone_number": "+351911111111",
+    "nationality": "GBR",
+    "phone_number_consent_granted": true,
+    "address": {
+      "country": "GBR",
+      "line1": "123rd Street",
+      "line2": "2nd Floor",
+      "line3": "23",
+      "town": "London",
+      "postcode": "S2 2DF"
+    }
+  }
+}


### PR DESCRIPTION
Add tests validating the outcome of Document and Facial Similarity reports, there should be no error deserialising the response when retrieving the reports.

The [output field of workflow runs](https://documentation.onfido.com/#workflow-run-object) is configured within Studio workflow builder and can yield anything the client configures.
The tests added validate there are no schema errors when the output is configured to be the result of a Profile Data Capture task, of a Document Report and of a Facial Similarity Photo Report.