### PR TITLE
Refresh onfido-java after onfido-openapi-spec update (e92d340)

### DIFF
--- a/.release.json
+++ b/.release.json
@@ -1,8 +1,8 @@
 {
   "source": {
     "repo_url": "https://github.com/onfido/onfido-openapi-spec",
-    "short_sha": "38a8740",
-    "long_sha": "38a87401552386cb0b17aae28385c5e2f4af7bfc",
+    "short_sha": "e92d340",
+    "long_sha": "e92d340b84690cce6851fa4a32530ac29911d75a",
     "version": ""
   },
   "release": "v4.0.0"

--- a/src/main/java/com/onfido/FileTransfer.java
+++ b/src/main/java/com/onfido/FileTransfer.java
@@ -1,0 +1,94 @@
+package com.onfido;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URLConnection;
+
+public class FileTransfer {
+
+  private File inputFile = null;
+  private byte[] byteArray = null;
+  private String filename = null;
+  private String contentType = null;
+
+  /**
+   * Create a new file transfer from a byte array
+   *
+   * @param byteArray Byte array to include in file transfer
+   * @param filename Filename to send together with the transfer
+   * @throws ApiException
+   */
+  public FileTransfer(byte[] byteArray, String filename) {
+    this.byteArray = byteArray;
+
+    updateMetadata(filename);
+  }
+
+  /**
+   * Create a new file transfer from a File
+   *
+   * @param file File to include in transfer
+   * @throws ApiException
+   */
+  public FileTransfer(File inputFile) {
+    this.inputFile = inputFile;
+
+    updateMetadata(inputFile.getName());
+  }
+
+  /**
+   * Create a new file transfer from an InputStream
+   *
+   * @param inputStream InputStream to read data from
+   * @param filename Filename to send together with the transfer
+   * @throws ApiException
+   */
+  public FileTransfer(InputStream inputStream, String filename) throws ApiException {
+    try {
+      this.byteArray = new byte[inputStream.available()];
+      inputStream.read(byteArray);
+    } catch (IOException e) {
+      throw new ApiException(e);
+    }
+
+    updateMetadata(filename);
+  }
+
+  /**
+   * Return the array of bytes used for this file transfer.
+   *
+   * @return array of bytes
+   */
+  public byte[] getByteArray() {
+    return byteArray;
+  }
+
+  /**
+   * Return the input stream used for this file transfer
+   *
+   * @return the provided input file
+   */
+  public File getInputFile() {
+    return inputFile;
+  }
+
+  /**
+   * @return the filename associated with this transfer
+   */
+  public String getFilename() {
+    return filename;
+  }
+
+  /**
+   * @return the content-type associated with this transfer
+   */
+  public String getContentType() {
+    return contentType;
+  }
+
+  private void updateMetadata(String filename) {
+    this.contentType = URLConnection.guessContentTypeFromName(filename);
+    this.filename = filename;
+  }
+}

--- a/src/main/java/com/onfido/api/DefaultApi.java
+++ b/src/main/java/com/onfido/api/DefaultApi.java
@@ -21,6 +21,7 @@ import com.onfido.Configuration;
 import com.onfido.Pair;
 import com.onfido.ProgressRequestBody;
 import com.onfido.ProgressResponseBody;
+import com.onfido.FileTransfer;
 
 import com.google.gson.reflect.TypeToken;
 
@@ -1592,7 +1593,7 @@ public class DefaultApi {
      * Download check
      * Downloads a PDF of a check with a given check ID. Returns the binary data representing the PDF. 
      * @param checkId  (required)
-     * @return File
+     * @return FileTransfer
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -1601,8 +1602,8 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public File downloadCheck(UUID checkId) throws ApiException {
-        ApiResponse<File> localVarResp = downloadCheckWithHttpInfo(checkId);
+    public FileTransfer downloadCheck(UUID checkId) throws ApiException {
+        ApiResponse<FileTransfer> localVarResp = downloadCheckWithHttpInfo(checkId);
         return localVarResp.getData();
     }
 
@@ -1610,7 +1611,7 @@ public class DefaultApi {
      * Download check
      * Downloads a PDF of a check with a given check ID. Returns the binary data representing the PDF. 
      * @param checkId  (required)
-     * @return ApiResponse&lt;File&gt;
+     * @return ApiResponse&lt;FileTransfer&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -1619,9 +1620,9 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<File> downloadCheckWithHttpInfo(UUID checkId) throws ApiException {
+    public ApiResponse<FileTransfer> downloadCheckWithHttpInfo(UUID checkId) throws ApiException {
         okhttp3.Call localVarCall = downloadCheckValidateBeforeCall(checkId, null);
-        Type localVarReturnType = new TypeToken<File>(){}.getType();
+        Type localVarReturnType = new TypeToken<FileTransfer>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
@@ -1639,10 +1640,10 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call downloadCheckAsync(UUID checkId, final ApiCallback<File> _callback) throws ApiException {
+    public okhttp3.Call downloadCheckAsync(UUID checkId, final ApiCallback<FileTransfer> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = downloadCheckValidateBeforeCall(checkId, _callback);
-        Type localVarReturnType = new TypeToken<File>(){}.getType();
+        Type localVarReturnType = new TypeToken<FileTransfer>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
@@ -1720,7 +1721,7 @@ public class DefaultApi {
      * Download document
      * Downloads specific documents belonging to an applicant. If successful, the response will be the binary data representing the image. 
      * @param documentId  (required)
-     * @return File
+     * @return FileTransfer
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -1729,8 +1730,8 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public File downloadDocument(UUID documentId) throws ApiException {
-        ApiResponse<File> localVarResp = downloadDocumentWithHttpInfo(documentId);
+    public FileTransfer downloadDocument(UUID documentId) throws ApiException {
+        ApiResponse<FileTransfer> localVarResp = downloadDocumentWithHttpInfo(documentId);
         return localVarResp.getData();
     }
 
@@ -1738,7 +1739,7 @@ public class DefaultApi {
      * Download document
      * Downloads specific documents belonging to an applicant. If successful, the response will be the binary data representing the image. 
      * @param documentId  (required)
-     * @return ApiResponse&lt;File&gt;
+     * @return ApiResponse&lt;FileTransfer&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -1747,9 +1748,9 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<File> downloadDocumentWithHttpInfo(UUID documentId) throws ApiException {
+    public ApiResponse<FileTransfer> downloadDocumentWithHttpInfo(UUID documentId) throws ApiException {
         okhttp3.Call localVarCall = downloadDocumentValidateBeforeCall(documentId, null);
-        Type localVarReturnType = new TypeToken<File>(){}.getType();
+        Type localVarReturnType = new TypeToken<FileTransfer>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
@@ -1767,10 +1768,10 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call downloadDocumentAsync(UUID documentId, final ApiCallback<File> _callback) throws ApiException {
+    public okhttp3.Call downloadDocumentAsync(UUID documentId, final ApiCallback<FileTransfer> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = downloadDocumentValidateBeforeCall(documentId, _callback);
-        Type localVarReturnType = new TypeToken<File>(){}.getType();
+        Type localVarReturnType = new TypeToken<FileTransfer>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
@@ -1848,7 +1849,7 @@ public class DefaultApi {
      * Download document video
      * Downloads a document video. If successful, the response will be the binary data representing the video. 
      * @param documentId  (required)
-     * @return File
+     * @return FileTransfer
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -1857,8 +1858,8 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public File downloadDocumentVideo(String documentId) throws ApiException {
-        ApiResponse<File> localVarResp = downloadDocumentVideoWithHttpInfo(documentId);
+    public FileTransfer downloadDocumentVideo(String documentId) throws ApiException {
+        ApiResponse<FileTransfer> localVarResp = downloadDocumentVideoWithHttpInfo(documentId);
         return localVarResp.getData();
     }
 
@@ -1866,7 +1867,7 @@ public class DefaultApi {
      * Download document video
      * Downloads a document video. If successful, the response will be the binary data representing the video. 
      * @param documentId  (required)
-     * @return ApiResponse&lt;File&gt;
+     * @return ApiResponse&lt;FileTransfer&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -1875,9 +1876,9 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<File> downloadDocumentVideoWithHttpInfo(String documentId) throws ApiException {
+    public ApiResponse<FileTransfer> downloadDocumentVideoWithHttpInfo(String documentId) throws ApiException {
         okhttp3.Call localVarCall = downloadDocumentVideoValidateBeforeCall(documentId, null);
-        Type localVarReturnType = new TypeToken<File>(){}.getType();
+        Type localVarReturnType = new TypeToken<FileTransfer>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
@@ -1895,10 +1896,10 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call downloadDocumentVideoAsync(String documentId, final ApiCallback<File> _callback) throws ApiException {
+    public okhttp3.Call downloadDocumentVideoAsync(String documentId, final ApiCallback<FileTransfer> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = downloadDocumentVideoValidateBeforeCall(documentId, _callback);
-        Type localVarReturnType = new TypeToken<File>(){}.getType();
+        Type localVarReturnType = new TypeToken<FileTransfer>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
@@ -1976,7 +1977,7 @@ public class DefaultApi {
      * Download ID photo
      * ID photos are downloaded using this endpoint.
      * @param idPhotoId The ID photo&#39;s unique identifier. (required)
-     * @return File
+     * @return FileTransfer
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -1985,8 +1986,8 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public File downloadIdPhoto(UUID idPhotoId) throws ApiException {
-        ApiResponse<File> localVarResp = downloadIdPhotoWithHttpInfo(idPhotoId);
+    public FileTransfer downloadIdPhoto(UUID idPhotoId) throws ApiException {
+        ApiResponse<FileTransfer> localVarResp = downloadIdPhotoWithHttpInfo(idPhotoId);
         return localVarResp.getData();
     }
 
@@ -1994,7 +1995,7 @@ public class DefaultApi {
      * Download ID photo
      * ID photos are downloaded using this endpoint.
      * @param idPhotoId The ID photo&#39;s unique identifier. (required)
-     * @return ApiResponse&lt;File&gt;
+     * @return ApiResponse&lt;FileTransfer&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -2003,9 +2004,9 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<File> downloadIdPhotoWithHttpInfo(UUID idPhotoId) throws ApiException {
+    public ApiResponse<FileTransfer> downloadIdPhotoWithHttpInfo(UUID idPhotoId) throws ApiException {
         okhttp3.Call localVarCall = downloadIdPhotoValidateBeforeCall(idPhotoId, null);
-        Type localVarReturnType = new TypeToken<File>(){}.getType();
+        Type localVarReturnType = new TypeToken<FileTransfer>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
@@ -2023,10 +2024,10 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call downloadIdPhotoAsync(UUID idPhotoId, final ApiCallback<File> _callback) throws ApiException {
+    public okhttp3.Call downloadIdPhotoAsync(UUID idPhotoId, final ApiCallback<FileTransfer> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = downloadIdPhotoValidateBeforeCall(idPhotoId, _callback);
-        Type localVarReturnType = new TypeToken<File>(){}.getType();
+        Type localVarReturnType = new TypeToken<FileTransfer>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
@@ -2104,7 +2105,7 @@ public class DefaultApi {
      * Download live photo
      * Live photos are downloaded using this endpoint.
      * @param livePhotoId The live photo&#39;s unique identifier. (required)
-     * @return File
+     * @return FileTransfer
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -2113,8 +2114,8 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public File downloadLivePhoto(UUID livePhotoId) throws ApiException {
-        ApiResponse<File> localVarResp = downloadLivePhotoWithHttpInfo(livePhotoId);
+    public FileTransfer downloadLivePhoto(UUID livePhotoId) throws ApiException {
+        ApiResponse<FileTransfer> localVarResp = downloadLivePhotoWithHttpInfo(livePhotoId);
         return localVarResp.getData();
     }
 
@@ -2122,7 +2123,7 @@ public class DefaultApi {
      * Download live photo
      * Live photos are downloaded using this endpoint.
      * @param livePhotoId The live photo&#39;s unique identifier. (required)
-     * @return ApiResponse&lt;File&gt;
+     * @return ApiResponse&lt;FileTransfer&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -2131,9 +2132,9 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<File> downloadLivePhotoWithHttpInfo(UUID livePhotoId) throws ApiException {
+    public ApiResponse<FileTransfer> downloadLivePhotoWithHttpInfo(UUID livePhotoId) throws ApiException {
         okhttp3.Call localVarCall = downloadLivePhotoValidateBeforeCall(livePhotoId, null);
-        Type localVarReturnType = new TypeToken<File>(){}.getType();
+        Type localVarReturnType = new TypeToken<FileTransfer>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
@@ -2151,10 +2152,10 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call downloadLivePhotoAsync(UUID livePhotoId, final ApiCallback<File> _callback) throws ApiException {
+    public okhttp3.Call downloadLivePhotoAsync(UUID livePhotoId, final ApiCallback<FileTransfer> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = downloadLivePhotoValidateBeforeCall(livePhotoId, _callback);
-        Type localVarReturnType = new TypeToken<File>(){}.getType();
+        Type localVarReturnType = new TypeToken<FileTransfer>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
@@ -2232,7 +2233,7 @@ public class DefaultApi {
      * Download live video
      * Live videos are downloaded using this endpoint.
      * @param liveVideoId The live video&#39;s unique identifier. (required)
-     * @return File
+     * @return FileTransfer
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -2241,8 +2242,8 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public File downloadLiveVideo(UUID liveVideoId) throws ApiException {
-        ApiResponse<File> localVarResp = downloadLiveVideoWithHttpInfo(liveVideoId);
+    public FileTransfer downloadLiveVideo(UUID liveVideoId) throws ApiException {
+        ApiResponse<FileTransfer> localVarResp = downloadLiveVideoWithHttpInfo(liveVideoId);
         return localVarResp.getData();
     }
 
@@ -2250,7 +2251,7 @@ public class DefaultApi {
      * Download live video
      * Live videos are downloaded using this endpoint.
      * @param liveVideoId The live video&#39;s unique identifier. (required)
-     * @return ApiResponse&lt;File&gt;
+     * @return ApiResponse&lt;FileTransfer&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -2259,9 +2260,9 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<File> downloadLiveVideoWithHttpInfo(UUID liveVideoId) throws ApiException {
+    public ApiResponse<FileTransfer> downloadLiveVideoWithHttpInfo(UUID liveVideoId) throws ApiException {
         okhttp3.Call localVarCall = downloadLiveVideoValidateBeforeCall(liveVideoId, null);
-        Type localVarReturnType = new TypeToken<File>(){}.getType();
+        Type localVarReturnType = new TypeToken<FileTransfer>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
@@ -2279,10 +2280,10 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call downloadLiveVideoAsync(UUID liveVideoId, final ApiCallback<File> _callback) throws ApiException {
+    public okhttp3.Call downloadLiveVideoAsync(UUID liveVideoId, final ApiCallback<FileTransfer> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = downloadLiveVideoValidateBeforeCall(liveVideoId, _callback);
-        Type localVarReturnType = new TypeToken<File>(){}.getType();
+        Type localVarReturnType = new TypeToken<FileTransfer>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
@@ -2360,7 +2361,7 @@ public class DefaultApi {
      * Download live video frame
      * Returns the binary data representing a single frame from a live video.
      * @param liveVideoId The live video&#39;s unique identifier. (required)
-     * @return File
+     * @return FileTransfer
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -2369,8 +2370,8 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public File downloadLiveVideoFrame(UUID liveVideoId) throws ApiException {
-        ApiResponse<File> localVarResp = downloadLiveVideoFrameWithHttpInfo(liveVideoId);
+    public FileTransfer downloadLiveVideoFrame(UUID liveVideoId) throws ApiException {
+        ApiResponse<FileTransfer> localVarResp = downloadLiveVideoFrameWithHttpInfo(liveVideoId);
         return localVarResp.getData();
     }
 
@@ -2378,7 +2379,7 @@ public class DefaultApi {
      * Download live video frame
      * Returns the binary data representing a single frame from a live video.
      * @param liveVideoId The live video&#39;s unique identifier. (required)
-     * @return ApiResponse&lt;File&gt;
+     * @return ApiResponse&lt;FileTransfer&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -2387,9 +2388,9 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<File> downloadLiveVideoFrameWithHttpInfo(UUID liveVideoId) throws ApiException {
+    public ApiResponse<FileTransfer> downloadLiveVideoFrameWithHttpInfo(UUID liveVideoId) throws ApiException {
         okhttp3.Call localVarCall = downloadLiveVideoFrameValidateBeforeCall(liveVideoId, null);
-        Type localVarReturnType = new TypeToken<File>(){}.getType();
+        Type localVarReturnType = new TypeToken<FileTransfer>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
@@ -2407,10 +2408,10 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call downloadLiveVideoFrameAsync(UUID liveVideoId, final ApiCallback<File> _callback) throws ApiException {
+    public okhttp3.Call downloadLiveVideoFrameAsync(UUID liveVideoId, final ApiCallback<FileTransfer> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = downloadLiveVideoFrameValidateBeforeCall(liveVideoId, _callback);
-        Type localVarReturnType = new TypeToken<File>(){}.getType();
+        Type localVarReturnType = new TypeToken<FileTransfer>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
@@ -2488,7 +2489,7 @@ public class DefaultApi {
      * Download motion capture
      * Motion captures are downloaded using this endpoint.
      * @param motionCaptureId The motion capture&#39;s unique identifier. (required)
-     * @return File
+     * @return FileTransfer
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -2497,8 +2498,8 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public File downloadMotionCapture(UUID motionCaptureId) throws ApiException {
-        ApiResponse<File> localVarResp = downloadMotionCaptureWithHttpInfo(motionCaptureId);
+    public FileTransfer downloadMotionCapture(UUID motionCaptureId) throws ApiException {
+        ApiResponse<FileTransfer> localVarResp = downloadMotionCaptureWithHttpInfo(motionCaptureId);
         return localVarResp.getData();
     }
 
@@ -2506,7 +2507,7 @@ public class DefaultApi {
      * Download motion capture
      * Motion captures are downloaded using this endpoint.
      * @param motionCaptureId The motion capture&#39;s unique identifier. (required)
-     * @return ApiResponse&lt;File&gt;
+     * @return ApiResponse&lt;FileTransfer&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -2515,9 +2516,9 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<File> downloadMotionCaptureWithHttpInfo(UUID motionCaptureId) throws ApiException {
+    public ApiResponse<FileTransfer> downloadMotionCaptureWithHttpInfo(UUID motionCaptureId) throws ApiException {
         okhttp3.Call localVarCall = downloadMotionCaptureValidateBeforeCall(motionCaptureId, null);
-        Type localVarReturnType = new TypeToken<File>(){}.getType();
+        Type localVarReturnType = new TypeToken<FileTransfer>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
@@ -2535,10 +2536,10 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call downloadMotionCaptureAsync(UUID motionCaptureId, final ApiCallback<File> _callback) throws ApiException {
+    public okhttp3.Call downloadMotionCaptureAsync(UUID motionCaptureId, final ApiCallback<FileTransfer> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = downloadMotionCaptureValidateBeforeCall(motionCaptureId, _callback);
-        Type localVarReturnType = new TypeToken<File>(){}.getType();
+        Type localVarReturnType = new TypeToken<FileTransfer>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
@@ -2616,7 +2617,7 @@ public class DefaultApi {
      * Download motion capture frame
      * Instead of the whole capture binary, a single frame can be downloaded using this endpoint. Returns the binary data representing the frame.
      * @param motionCaptureId The motion capture&#39;s unique identifier. (required)
-     * @return File
+     * @return FileTransfer
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -2625,8 +2626,8 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public File downloadMotionCaptureFrame(UUID motionCaptureId) throws ApiException {
-        ApiResponse<File> localVarResp = downloadMotionCaptureFrameWithHttpInfo(motionCaptureId);
+    public FileTransfer downloadMotionCaptureFrame(UUID motionCaptureId) throws ApiException {
+        ApiResponse<FileTransfer> localVarResp = downloadMotionCaptureFrameWithHttpInfo(motionCaptureId);
         return localVarResp.getData();
     }
 
@@ -2634,7 +2635,7 @@ public class DefaultApi {
      * Download motion capture frame
      * Instead of the whole capture binary, a single frame can be downloaded using this endpoint. Returns the binary data representing the frame.
      * @param motionCaptureId The motion capture&#39;s unique identifier. (required)
-     * @return ApiResponse&lt;File&gt;
+     * @return ApiResponse&lt;FileTransfer&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -2643,9 +2644,9 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<File> downloadMotionCaptureFrameWithHttpInfo(UUID motionCaptureId) throws ApiException {
+    public ApiResponse<FileTransfer> downloadMotionCaptureFrameWithHttpInfo(UUID motionCaptureId) throws ApiException {
         okhttp3.Call localVarCall = downloadMotionCaptureFrameValidateBeforeCall(motionCaptureId, null);
-        Type localVarReturnType = new TypeToken<File>(){}.getType();
+        Type localVarReturnType = new TypeToken<FileTransfer>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
@@ -2663,10 +2664,10 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call downloadMotionCaptureFrameAsync(UUID motionCaptureId, final ApiCallback<File> _callback) throws ApiException {
+    public okhttp3.Call downloadMotionCaptureFrameAsync(UUID motionCaptureId, final ApiCallback<FileTransfer> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = downloadMotionCaptureFrameValidateBeforeCall(motionCaptureId, _callback);
-        Type localVarReturnType = new TypeToken<File>(){}.getType();
+        Type localVarReturnType = new TypeToken<FileTransfer>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
@@ -2745,7 +2746,7 @@ public class DefaultApi {
      * Retrieve Workflow Run Evidence Summary File
      * Retrieves the signed evidence file for the designated Workflow Run 
      * @param workflowRunId Workflow Run ID (required)
-     * @return File
+     * @return FileTransfer
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -2755,8 +2756,8 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public File downloadSignedEvidenceFile(UUID workflowRunId) throws ApiException {
-        ApiResponse<File> localVarResp = downloadSignedEvidenceFileWithHttpInfo(workflowRunId);
+    public FileTransfer downloadSignedEvidenceFile(UUID workflowRunId) throws ApiException {
+        ApiResponse<FileTransfer> localVarResp = downloadSignedEvidenceFileWithHttpInfo(workflowRunId);
         return localVarResp.getData();
     }
 
@@ -2764,7 +2765,7 @@ public class DefaultApi {
      * Retrieve Workflow Run Evidence Summary File
      * Retrieves the signed evidence file for the designated Workflow Run 
      * @param workflowRunId Workflow Run ID (required)
-     * @return ApiResponse&lt;File&gt;
+     * @return ApiResponse&lt;FileTransfer&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -2774,9 +2775,9 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<File> downloadSignedEvidenceFileWithHttpInfo(UUID workflowRunId) throws ApiException {
+    public ApiResponse<FileTransfer> downloadSignedEvidenceFileWithHttpInfo(UUID workflowRunId) throws ApiException {
         okhttp3.Call localVarCall = downloadSignedEvidenceFileValidateBeforeCall(workflowRunId, null);
-        Type localVarReturnType = new TypeToken<File>(){}.getType();
+        Type localVarReturnType = new TypeToken<FileTransfer>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
@@ -2795,10 +2796,10 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call downloadSignedEvidenceFileAsync(UUID workflowRunId, final ApiCallback<File> _callback) throws ApiException {
+    public okhttp3.Call downloadSignedEvidenceFileAsync(UUID workflowRunId, final ApiCallback<FileTransfer> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = downloadSignedEvidenceFileValidateBeforeCall(workflowRunId, _callback);
-        Type localVarReturnType = new TypeToken<File>(){}.getType();
+        Type localVarReturnType = new TypeToken<FileTransfer>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
@@ -4295,7 +4296,7 @@ public class DefaultApi {
      * Retrieves the Timeline File for the designated Workflow Run. 
      * @param workflowRunId The unique identifier of the Workflow Run. (required)
      * @param timelineFileId The unique identifier for the Timefile File. (required)
-     * @return File
+     * @return FileTransfer
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -4305,8 +4306,8 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public File findTimelineFile(UUID workflowRunId, UUID timelineFileId) throws ApiException {
-        ApiResponse<File> localVarResp = findTimelineFileWithHttpInfo(workflowRunId, timelineFileId);
+    public FileTransfer findTimelineFile(UUID workflowRunId, UUID timelineFileId) throws ApiException {
+        ApiResponse<FileTransfer> localVarResp = findTimelineFileWithHttpInfo(workflowRunId, timelineFileId);
         return localVarResp.getData();
     }
 
@@ -4315,7 +4316,7 @@ public class DefaultApi {
      * Retrieves the Timeline File for the designated Workflow Run. 
      * @param workflowRunId The unique identifier of the Workflow Run. (required)
      * @param timelineFileId The unique identifier for the Timefile File. (required)
-     * @return ApiResponse&lt;File&gt;
+     * @return ApiResponse&lt;FileTransfer&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
@@ -4325,9 +4326,9 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<File> findTimelineFileWithHttpInfo(UUID workflowRunId, UUID timelineFileId) throws ApiException {
+    public ApiResponse<FileTransfer> findTimelineFileWithHttpInfo(UUID workflowRunId, UUID timelineFileId) throws ApiException {
         okhttp3.Call localVarCall = findTimelineFileValidateBeforeCall(workflowRunId, timelineFileId, null);
-        Type localVarReturnType = new TypeToken<File>(){}.getType();
+        Type localVarReturnType = new TypeToken<FileTransfer>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
@@ -4347,10 +4348,10 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call findTimelineFileAsync(UUID workflowRunId, UUID timelineFileId, final ApiCallback<File> _callback) throws ApiException {
+    public okhttp3.Call findTimelineFileAsync(UUID workflowRunId, UUID timelineFileId, final ApiCallback<FileTransfer> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = findTimelineFileValidateBeforeCall(workflowRunId, timelineFileId, _callback);
-        Type localVarReturnType = new TypeToken<File>(){}.getType();
+        Type localVarReturnType = new TypeToken<FileTransfer>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
@@ -7997,7 +7998,7 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call uploadDocumentCall(String type, UUID applicantId, File _file, String fileType, String side, CountryCodes issuingCountry, Boolean validateImageQuality, LocationBuilder location, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call uploadDocumentCall(String type, UUID applicantId, FileTransfer _file, String fileType, String side, CountryCodes issuingCountry, Boolean validateImageQuality, LocationBuilder location, final ApiCallback _callback) throws ApiException {
         String basePath = null;
         // Operation Servers
         String[] localBasePaths = new String[] {  };
@@ -8075,7 +8076,7 @@ public class DefaultApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call uploadDocumentValidateBeforeCall(String type, UUID applicantId, File _file, String fileType, String side, CountryCodes issuingCountry, Boolean validateImageQuality, LocationBuilder location, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call uploadDocumentValidateBeforeCall(String type, UUID applicantId, FileTransfer _file, String fileType, String side, CountryCodes issuingCountry, Boolean validateImageQuality, LocationBuilder location, final ApiCallback _callback) throws ApiException {
         // verify the required parameter 'type' is set
         if (type == null) {
             throw new ApiException("Missing the required parameter 'type' when calling uploadDocument(Async)");
@@ -8115,7 +8116,7 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public Document uploadDocument(String type, UUID applicantId, File _file, String fileType, String side, CountryCodes issuingCountry, Boolean validateImageQuality, LocationBuilder location) throws ApiException {
+    public Document uploadDocument(String type, UUID applicantId, FileTransfer _file, String fileType, String side, CountryCodes issuingCountry, Boolean validateImageQuality, LocationBuilder location) throws ApiException {
         ApiResponse<Document> localVarResp = uploadDocumentWithHttpInfo(type, applicantId, _file, fileType, side, issuingCountry, validateImageQuality, location);
         return localVarResp.getData();
     }
@@ -8140,7 +8141,7 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Document> uploadDocumentWithHttpInfo(String type, UUID applicantId, File _file, String fileType, String side, CountryCodes issuingCountry, Boolean validateImageQuality, LocationBuilder location) throws ApiException {
+    public ApiResponse<Document> uploadDocumentWithHttpInfo(String type, UUID applicantId, FileTransfer _file, String fileType, String side, CountryCodes issuingCountry, Boolean validateImageQuality, LocationBuilder location) throws ApiException {
         okhttp3.Call localVarCall = uploadDocumentValidateBeforeCall(type, applicantId, _file, fileType, side, issuingCountry, validateImageQuality, location, null);
         Type localVarReturnType = new TypeToken<Document>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
@@ -8167,7 +8168,7 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call uploadDocumentAsync(String type, UUID applicantId, File _file, String fileType, String side, CountryCodes issuingCountry, Boolean validateImageQuality, LocationBuilder location, final ApiCallback<Document> _callback) throws ApiException {
+    public okhttp3.Call uploadDocumentAsync(String type, UUID applicantId, FileTransfer _file, String fileType, String side, CountryCodes issuingCountry, Boolean validateImageQuality, LocationBuilder location, final ApiCallback<Document> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = uploadDocumentValidateBeforeCall(type, applicantId, _file, fileType, side, issuingCountry, validateImageQuality, location, _callback);
         Type localVarReturnType = new TypeToken<Document>(){}.getType();
@@ -8188,7 +8189,7 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call uploadIdPhotoCall(UUID applicantId, File _file, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call uploadIdPhotoCall(UUID applicantId, FileTransfer _file, final ApiCallback _callback) throws ApiException {
         String basePath = null;
         // Operation Servers
         String[] localBasePaths = new String[] {  };
@@ -8242,7 +8243,7 @@ public class DefaultApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call uploadIdPhotoValidateBeforeCall(UUID applicantId, File _file, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call uploadIdPhotoValidateBeforeCall(UUID applicantId, FileTransfer _file, final ApiCallback _callback) throws ApiException {
         return uploadIdPhotoCall(applicantId, _file, _callback);
 
     }
@@ -8261,7 +8262,7 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public IdPhoto uploadIdPhoto(UUID applicantId, File _file) throws ApiException {
+    public IdPhoto uploadIdPhoto(UUID applicantId, FileTransfer _file) throws ApiException {
         ApiResponse<IdPhoto> localVarResp = uploadIdPhotoWithHttpInfo(applicantId, _file);
         return localVarResp.getData();
     }
@@ -8280,7 +8281,7 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<IdPhoto> uploadIdPhotoWithHttpInfo(UUID applicantId, File _file) throws ApiException {
+    public ApiResponse<IdPhoto> uploadIdPhotoWithHttpInfo(UUID applicantId, FileTransfer _file) throws ApiException {
         okhttp3.Call localVarCall = uploadIdPhotoValidateBeforeCall(applicantId, _file, null);
         Type localVarReturnType = new TypeToken<IdPhoto>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
@@ -8301,7 +8302,7 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call uploadIdPhotoAsync(UUID applicantId, File _file, final ApiCallback<IdPhoto> _callback) throws ApiException {
+    public okhttp3.Call uploadIdPhotoAsync(UUID applicantId, FileTransfer _file, final ApiCallback<IdPhoto> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = uploadIdPhotoValidateBeforeCall(applicantId, _file, _callback);
         Type localVarReturnType = new TypeToken<IdPhoto>(){}.getType();
@@ -8323,7 +8324,7 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call uploadLivePhotoCall(UUID applicantId, File _file, Boolean advancedValidation, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call uploadLivePhotoCall(UUID applicantId, FileTransfer _file, Boolean advancedValidation, final ApiCallback _callback) throws ApiException {
         String basePath = null;
         // Operation Servers
         String[] localBasePaths = new String[] {  };
@@ -8381,7 +8382,7 @@ public class DefaultApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call uploadLivePhotoValidateBeforeCall(UUID applicantId, File _file, Boolean advancedValidation, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call uploadLivePhotoValidateBeforeCall(UUID applicantId, FileTransfer _file, Boolean advancedValidation, final ApiCallback _callback) throws ApiException {
         return uploadLivePhotoCall(applicantId, _file, advancedValidation, _callback);
 
     }
@@ -8401,7 +8402,7 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public LivePhoto uploadLivePhoto(UUID applicantId, File _file, Boolean advancedValidation) throws ApiException {
+    public LivePhoto uploadLivePhoto(UUID applicantId, FileTransfer _file, Boolean advancedValidation) throws ApiException {
         ApiResponse<LivePhoto> localVarResp = uploadLivePhotoWithHttpInfo(applicantId, _file, advancedValidation);
         return localVarResp.getData();
     }
@@ -8421,7 +8422,7 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<LivePhoto> uploadLivePhotoWithHttpInfo(UUID applicantId, File _file, Boolean advancedValidation) throws ApiException {
+    public ApiResponse<LivePhoto> uploadLivePhotoWithHttpInfo(UUID applicantId, FileTransfer _file, Boolean advancedValidation) throws ApiException {
         okhttp3.Call localVarCall = uploadLivePhotoValidateBeforeCall(applicantId, _file, advancedValidation, null);
         Type localVarReturnType = new TypeToken<LivePhoto>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
@@ -8443,7 +8444,7 @@ public class DefaultApi {
         <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call uploadLivePhotoAsync(UUID applicantId, File _file, Boolean advancedValidation, final ApiCallback<LivePhoto> _callback) throws ApiException {
+    public okhttp3.Call uploadLivePhotoAsync(UUID applicantId, FileTransfer _file, Boolean advancedValidation, final ApiCallback<LivePhoto> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = uploadLivePhotoValidateBeforeCall(applicantId, _file, advancedValidation, _callback);
         Type localVarReturnType = new TypeToken<LivePhoto>(){}.getType();

--- a/src/main/java/com/onfido/model/CompleteTaskDataBuilder.java
+++ b/src/main/java/com/onfido/model/CompleteTaskDataBuilder.java
@@ -225,6 +225,7 @@ public class CompleteTaskDataBuilder extends AbstractOpenApiSchema {
      * @return The actual instance of `List<Object>`
      * @throws ClassCastException if the instance is not `List<Object>`
      */
+    @SuppressWarnings("unchecked")
     public List<Object> getListObject() throws ClassCastException {
         return (List<Object>)super.getActualInstance();
     }
@@ -235,6 +236,7 @@ public class CompleteTaskDataBuilder extends AbstractOpenApiSchema {
      * @return The actual instance of `Object`
      * @throws ClassCastException if the instance is not `Object`
      */
+    @SuppressWarnings("unchecked")
     public Object getObject() throws ClassCastException {
         return (Object)super.getActualInstance();
     }
@@ -302,32 +304,41 @@ public class CompleteTaskDataBuilder extends AbstractOpenApiSchema {
     }
 
 
-  /**
-  * Give access to shared properties. Read-only.
-  * @return ReportShared object with common fields
-  **/
+    /**
+     * Give access to shared properties. Read-only.
+     * @return ReportShared object with common fields
+     **/
 
-  public ReportShared getReportShared() {
-      return reportShared;
-  }
+    public ReportShared getReportShared() {
+        return reportShared;
+    }
 
-  /**
-  * Give access to shared properties. Read-only.
-  * @return id
-  **/
+    /**
+     * Give access to shared properties. Read-only.
+     * @return id
+     **/
 
-  public UUID getId() {
-      return reportShared.getId();
-  }
+    public UUID getId() {
+        return reportShared.getId();
+    }
 
-  /**
-  * Get name
-  * @return name
-  **/
+    /**
+     * Get name
+     * @return name
+     **/
 
-  public ReportName getName() {
-      return reportShared.getName();
-  }
+    public ReportName getName() {
+        return reportShared.getName();
+    }
+
+    /**
+     * Get status
+     * @return status
+     **/
+
+    public ReportStatus getStatus() {
+        return reportShared.getStatus();
+    }
 
 }
 

--- a/src/main/java/com/onfido/model/Report.java
+++ b/src/main/java/com/onfido/model/Report.java
@@ -1000,6 +1000,7 @@ public class Report extends AbstractOpenApiSchema {
      * @return The actual instance of `DocumentReport`
      * @throws ClassCastException if the instance is not `DocumentReport`
      */
+    @SuppressWarnings("unchecked")
     public DocumentReport getDocumentReport() throws ClassCastException {
         return (DocumentReport)super.getActualInstance();
     }
@@ -1010,6 +1011,7 @@ public class Report extends AbstractOpenApiSchema {
      * @return The actual instance of `DocumentVideoReport`
      * @throws ClassCastException if the instance is not `DocumentVideoReport`
      */
+    @SuppressWarnings("unchecked")
     public DocumentVideoReport getDocumentVideoReport() throws ClassCastException {
         return (DocumentVideoReport)super.getActualInstance();
     }
@@ -1020,6 +1022,7 @@ public class Report extends AbstractOpenApiSchema {
      * @return The actual instance of `DocumentVideoWithAddressInformationReport`
      * @throws ClassCastException if the instance is not `DocumentVideoWithAddressInformationReport`
      */
+    @SuppressWarnings("unchecked")
     public DocumentVideoWithAddressInformationReport getDocumentVideoWithAddressInformationReport() throws ClassCastException {
         return (DocumentVideoWithAddressInformationReport)super.getActualInstance();
     }
@@ -1030,6 +1033,7 @@ public class Report extends AbstractOpenApiSchema {
      * @return The actual instance of `DocumentWithAddressInformationReport`
      * @throws ClassCastException if the instance is not `DocumentWithAddressInformationReport`
      */
+    @SuppressWarnings("unchecked")
     public DocumentWithAddressInformationReport getDocumentWithAddressInformationReport() throws ClassCastException {
         return (DocumentWithAddressInformationReport)super.getActualInstance();
     }
@@ -1040,6 +1044,7 @@ public class Report extends AbstractOpenApiSchema {
      * @return The actual instance of `DocumentWithDrivingLicenceInformationReport`
      * @throws ClassCastException if the instance is not `DocumentWithDrivingLicenceInformationReport`
      */
+    @SuppressWarnings("unchecked")
     public DocumentWithDrivingLicenceInformationReport getDocumentWithDrivingLicenceInformationReport() throws ClassCastException {
         return (DocumentWithDrivingLicenceInformationReport)super.getActualInstance();
     }
@@ -1050,6 +1055,7 @@ public class Report extends AbstractOpenApiSchema {
      * @return The actual instance of `DocumentWithDriverVerificationReport`
      * @throws ClassCastException if the instance is not `DocumentWithDriverVerificationReport`
      */
+    @SuppressWarnings("unchecked")
     public DocumentWithDriverVerificationReport getDocumentWithDriverVerificationReport() throws ClassCastException {
         return (DocumentWithDriverVerificationReport)super.getActualInstance();
     }
@@ -1060,6 +1066,7 @@ public class Report extends AbstractOpenApiSchema {
      * @return The actual instance of `FacialSimilarityPhotoReport`
      * @throws ClassCastException if the instance is not `FacialSimilarityPhotoReport`
      */
+    @SuppressWarnings("unchecked")
     public FacialSimilarityPhotoReport getFacialSimilarityPhotoReport() throws ClassCastException {
         return (FacialSimilarityPhotoReport)super.getActualInstance();
     }
@@ -1070,6 +1077,7 @@ public class Report extends AbstractOpenApiSchema {
      * @return The actual instance of `FacialSimilarityPhotoFullyAutoReport`
      * @throws ClassCastException if the instance is not `FacialSimilarityPhotoFullyAutoReport`
      */
+    @SuppressWarnings("unchecked")
     public FacialSimilarityPhotoFullyAutoReport getFacialSimilarityPhotoFullyAutoReport() throws ClassCastException {
         return (FacialSimilarityPhotoFullyAutoReport)super.getActualInstance();
     }
@@ -1080,6 +1088,7 @@ public class Report extends AbstractOpenApiSchema {
      * @return The actual instance of `FacialSimilarityVideoReport`
      * @throws ClassCastException if the instance is not `FacialSimilarityVideoReport`
      */
+    @SuppressWarnings("unchecked")
     public FacialSimilarityVideoReport getFacialSimilarityVideoReport() throws ClassCastException {
         return (FacialSimilarityVideoReport)super.getActualInstance();
     }
@@ -1090,6 +1099,7 @@ public class Report extends AbstractOpenApiSchema {
      * @return The actual instance of `FacialSimilarityMotionReport`
      * @throws ClassCastException if the instance is not `FacialSimilarityMotionReport`
      */
+    @SuppressWarnings("unchecked")
     public FacialSimilarityMotionReport getFacialSimilarityMotionReport() throws ClassCastException {
         return (FacialSimilarityMotionReport)super.getActualInstance();
     }
@@ -1100,6 +1110,7 @@ public class Report extends AbstractOpenApiSchema {
      * @return The actual instance of `KnownFacesReport`
      * @throws ClassCastException if the instance is not `KnownFacesReport`
      */
+    @SuppressWarnings("unchecked")
     public KnownFacesReport getKnownFacesReport() throws ClassCastException {
         return (KnownFacesReport)super.getActualInstance();
     }
@@ -1110,6 +1121,7 @@ public class Report extends AbstractOpenApiSchema {
      * @return The actual instance of `IdentityEnhancedReport`
      * @throws ClassCastException if the instance is not `IdentityEnhancedReport`
      */
+    @SuppressWarnings("unchecked")
     public IdentityEnhancedReport getIdentityEnhancedReport() throws ClassCastException {
         return (IdentityEnhancedReport)super.getActualInstance();
     }
@@ -1120,6 +1132,7 @@ public class Report extends AbstractOpenApiSchema {
      * @return The actual instance of `WatchlistAmlReport`
      * @throws ClassCastException if the instance is not `WatchlistAmlReport`
      */
+    @SuppressWarnings("unchecked")
     public WatchlistAmlReport getWatchlistAmlReport() throws ClassCastException {
         return (WatchlistAmlReport)super.getActualInstance();
     }
@@ -1130,6 +1143,7 @@ public class Report extends AbstractOpenApiSchema {
      * @return The actual instance of `WatchlistEnhancedReport`
      * @throws ClassCastException if the instance is not `WatchlistEnhancedReport`
      */
+    @SuppressWarnings("unchecked")
     public WatchlistEnhancedReport getWatchlistEnhancedReport() throws ClassCastException {
         return (WatchlistEnhancedReport)super.getActualInstance();
     }
@@ -1140,6 +1154,7 @@ public class Report extends AbstractOpenApiSchema {
      * @return The actual instance of `WatchlistStandardReport`
      * @throws ClassCastException if the instance is not `WatchlistStandardReport`
      */
+    @SuppressWarnings("unchecked")
     public WatchlistStandardReport getWatchlistStandardReport() throws ClassCastException {
         return (WatchlistStandardReport)super.getActualInstance();
     }
@@ -1150,6 +1165,7 @@ public class Report extends AbstractOpenApiSchema {
      * @return The actual instance of `WatchlistPepsOnlyReport`
      * @throws ClassCastException if the instance is not `WatchlistPepsOnlyReport`
      */
+    @SuppressWarnings("unchecked")
     public WatchlistPepsOnlyReport getWatchlistPepsOnlyReport() throws ClassCastException {
         return (WatchlistPepsOnlyReport)super.getActualInstance();
     }
@@ -1160,6 +1176,7 @@ public class Report extends AbstractOpenApiSchema {
      * @return The actual instance of `WatchlistSanctionsOnlyReport`
      * @throws ClassCastException if the instance is not `WatchlistSanctionsOnlyReport`
      */
+    @SuppressWarnings("unchecked")
     public WatchlistSanctionsOnlyReport getWatchlistSanctionsOnlyReport() throws ClassCastException {
         return (WatchlistSanctionsOnlyReport)super.getActualInstance();
     }
@@ -1170,6 +1187,7 @@ public class Report extends AbstractOpenApiSchema {
      * @return The actual instance of `ProofOfAddressReport`
      * @throws ClassCastException if the instance is not `ProofOfAddressReport`
      */
+    @SuppressWarnings("unchecked")
     public ProofOfAddressReport getProofOfAddressReport() throws ClassCastException {
         return (ProofOfAddressReport)super.getActualInstance();
     }
@@ -1180,6 +1198,7 @@ public class Report extends AbstractOpenApiSchema {
      * @return The actual instance of `UsDrivingLicenceReport`
      * @throws ClassCastException if the instance is not `UsDrivingLicenceReport`
      */
+    @SuppressWarnings("unchecked")
     public UsDrivingLicenceReport getUsDrivingLicenceReport() throws ClassCastException {
         return (UsDrivingLicenceReport)super.getActualInstance();
     }
@@ -1190,6 +1209,7 @@ public class Report extends AbstractOpenApiSchema {
      * @return The actual instance of `DeviceIntelligenceReport`
      * @throws ClassCastException if the instance is not `DeviceIntelligenceReport`
      */
+    @SuppressWarnings("unchecked")
     public DeviceIntelligenceReport getDeviceIntelligenceReport() throws ClassCastException {
         return (DeviceIntelligenceReport)super.getActualInstance();
     }
@@ -1200,6 +1220,7 @@ public class Report extends AbstractOpenApiSchema {
      * @return The actual instance of `IndiaPanReport`
      * @throws ClassCastException if the instance is not `IndiaPanReport`
      */
+    @SuppressWarnings("unchecked")
     public IndiaPanReport getIndiaPanReport() throws ClassCastException {
         return (IndiaPanReport)super.getActualInstance();
     }
@@ -1408,32 +1429,41 @@ public class Report extends AbstractOpenApiSchema {
     }
 
 
-  /**
-  * Give access to shared properties. Read-only.
-  * @return ReportShared object with common fields
-  **/
+    /**
+     * Give access to shared properties. Read-only.
+     * @return ReportShared object with common fields
+     **/
 
-  public ReportShared getReportShared() {
-      return reportShared;
-  }
+    public ReportShared getReportShared() {
+        return reportShared;
+    }
 
-  /**
-  * Give access to shared properties. Read-only.
-  * @return id
-  **/
+    /**
+     * Give access to shared properties. Read-only.
+     * @return id
+     **/
 
-  public UUID getId() {
-      return reportShared.getId();
-  }
+    public UUID getId() {
+        return reportShared.getId();
+    }
 
-  /**
-  * Get name
-  * @return name
-  **/
+    /**
+     * Get name
+     * @return name
+     **/
 
-  public ReportName getName() {
-      return reportShared.getName();
-  }
+    public ReportName getName() {
+        return reportShared.getName();
+    }
+
+    /**
+     * Get status
+     * @return status
+     **/
+
+    public ReportStatus getStatus() {
+        return reportShared.getStatus();
+    }
 
 }
 

--- a/src/test/java/com/onfido/FileTransferTest.java
+++ b/src/test/java/com/onfido/FileTransferTest.java
@@ -1,0 +1,49 @@
+package com.onfido;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class FileTransferTest {
+
+  private static File VALID_FILE = new File("media/sample_photo.png");
+
+  private static byte[] byteArray;
+
+  @BeforeEach
+  void init() throws IOException {
+    byteArray = Files.readAllBytes(VALID_FILE.toPath());
+  }
+
+  @Test
+  public void createFromByteArray() throws ApiException {
+    FileTransfer fileTransfer = new FileTransfer(byteArray, "test-file.jpg");
+
+    Assertions.assertEquals(byteArray, fileTransfer.getByteArray());
+    Assertions.assertEquals("image/jpeg", fileTransfer.getContentType());
+    Assertions.assertEquals("test-file.jpg", fileTransfer.getFilename());
+  }
+
+  @Test
+  public void createFromFile() throws ApiException {
+    FileTransfer fileTransfer = new FileTransfer(VALID_FILE);
+
+    Assertions.assertSame(VALID_FILE, fileTransfer.getInputFile());
+    Assertions.assertEquals("image/png", fileTransfer.getContentType());
+    Assertions.assertEquals("sample_photo.png", fileTransfer.getFilename());
+  }
+
+  @Test
+  public void createFromInputStream() throws ApiException, FileNotFoundException {
+    FileTransfer fileTransfer = new FileTransfer(new FileInputStream(VALID_FILE), "test-file.pdf");
+
+    Assertions.assertArrayEquals(byteArray, fileTransfer.getByteArray());
+    Assertions.assertEquals("application/pdf", fileTransfer.getContentType());
+    Assertions.assertEquals("test-file.pdf", fileTransfer.getFilename());
+  }
+}

--- a/src/test/java/com/onfido/integration/CheckTest.java
+++ b/src/test/java/com/onfido/integration/CheckTest.java
@@ -1,12 +1,12 @@
 package com.onfido.integration;
 
+import com.onfido.FileTransfer;
 import com.onfido.model.Applicant;
 import com.onfido.model.Check;
 import com.onfido.model.CheckBuilder;
 import com.onfido.model.Document;
 import com.onfido.model.ReportName;
 import com.onfido.model.UsDrivingLicenceBuilder;
-import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
@@ -117,7 +117,12 @@ public class CheckTest extends TestBase {
             document,
             new CheckBuilder().reportNames(Arrays.asList(ReportName.DOCUMENT)));
 
-    File download = onfido.downloadCheck(check.getId());
-    Assertions.assertTrue(download.length() > 0);
+    FileTransfer download = onfido.downloadCheck(check.getId());
+    byte[] byteArray = download.getByteArray();
+
+    Assertions.assertEquals("application/pdf", download.getContentType());
+    Assertions.assertTrue(download.getFilename() != null);
+    Assertions.assertTrue(byteArray.length > 0);
+    Assertions.assertEquals("%PDF", new String(byteArray, 0, 4));
   }
 }

--- a/src/test/java/com/onfido/integration/DocumentTest.java
+++ b/src/test/java/com/onfido/integration/DocumentTest.java
@@ -1,9 +1,9 @@
 package com.onfido.integration;
 
 import com.onfido.ApiException;
+import com.onfido.FileTransfer;
 import com.onfido.model.Applicant;
 import com.onfido.model.Document;
-import java.io.File;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -28,9 +28,11 @@ public class DocumentTest extends TestBase {
 
   @Test
   public void downloadDocumentTest() throws Exception {
-    File download = onfido.downloadDocument(document.getId());
+    FileTransfer download = onfido.downloadDocument(document.getId());
 
-    Assertions.assertTrue(download.length() > 0);
+    Assertions.assertEquals("image/png", download.getContentType());
+    Assertions.assertTrue(download.getFilename() != null);
+    Assertions.assertTrue(download.getByteArray().length > 0);
   }
 
   @Test

--- a/src/test/java/com/onfido/integration/IdPhotoTest.java
+++ b/src/test/java/com/onfido/integration/IdPhotoTest.java
@@ -1,9 +1,9 @@
 package com.onfido.integration;
 
 import com.onfido.ApiException;
+import com.onfido.FileTransfer;
 import com.onfido.model.Applicant;
 import com.onfido.model.IdPhoto;
-import java.io.File;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -29,9 +29,11 @@ public class IdPhotoTest extends TestBase {
 
   @Test
   public void downloadIdPhotoTest() throws Exception {
-    File download = onfido.downloadIdPhoto(idPhoto.getId());
+    FileTransfer download = onfido.downloadIdPhoto(idPhoto.getId());
 
-    Assertions.assertTrue(download.length() > 0);
+    Assertions.assertEquals("image/png", download.getContentType());
+    Assertions.assertTrue(download.getFilename() != null);
+    Assertions.assertTrue(download.getByteArray().length > 0);
   }
 
   @Test

--- a/src/test/java/com/onfido/integration/LivePhotoTest.java
+++ b/src/test/java/com/onfido/integration/LivePhotoTest.java
@@ -1,9 +1,9 @@
 package com.onfido.integration;
 
 import com.onfido.ApiException;
+import com.onfido.FileTransfer;
 import com.onfido.model.Applicant;
 import com.onfido.model.LivePhoto;
-import java.io.File;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -29,9 +29,11 @@ public class LivePhotoTest extends TestBase {
 
   @Test
   public void downloadLivePhotoTest() throws Exception {
-    File download = onfido.downloadLivePhoto(livePhoto.getId());
+    FileTransfer download = onfido.downloadLivePhoto(livePhoto.getId());
 
-    Assertions.assertTrue(download.length() > 0);
+    Assertions.assertEquals("image/png", download.getContentType());
+    Assertions.assertEquals("sample_photo.png", download.getFilename());
+    Assertions.assertTrue(download.getByteArray().length > 0);
   }
 
   @Test

--- a/src/test/java/com/onfido/integration/LiveVideoTest.java
+++ b/src/test/java/com/onfido/integration/LiveVideoTest.java
@@ -1,9 +1,8 @@
 package com.onfido.integration;
 
 import com.onfido.ApiException;
+import com.onfido.FileTransfer;
 import com.onfido.model.LiveVideo;
-import java.io.File;
-import java.nio.file.Files;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
@@ -16,18 +15,21 @@ public class LiveVideoTest extends TestBase {
 
   @Test
   public void downloadLiveVideoTest() throws Exception {
-    File download = onfido.downloadLiveVideo(sampleLiveVideoId1);
+    FileTransfer download = onfido.downloadLiveVideo(sampleLiveVideoId1);
 
-    Assertions.assertTrue(download.length() > 0);
+    Assertions.assertEquals("video/quicktime", download.getContentType());
+    Assertions.assertEquals("video.mov", download.getFilename());
+    Assertions.assertTrue(download.getByteArray().length > 0);
   }
 
   @Test
   public void downloadLiveVideoFrameTest() throws Exception {
     try {
-      File download = onfido.downloadLiveVideoFrame(sampleLiveVideoId1);
-      byte[] content = Files.readAllBytes(download.toPath());
+      FileTransfer download = onfido.downloadLiveVideoFrame(sampleLiveVideoId1);
 
-      Assertions.assertEquals("JFIF", new String(content, 6, 4));
+      Assertions.assertEquals("image/jpeg", download.getContentType());
+      Assertions.assertTrue(download.getFilename() != null);
+      Assertions.assertEquals("JFIF", new String(download.getByteArray(), 6, 4));
     } catch (ApiException ex) {
       Assertions.assertEquals(422, ex.getCode());
       Assertions.assertEquals(

--- a/src/test/java/com/onfido/integration/MotionCaptureTest.java
+++ b/src/test/java/com/onfido/integration/MotionCaptureTest.java
@@ -1,9 +1,8 @@
 package com.onfido.integration;
 
 import com.onfido.ApiException;
+import com.onfido.FileTransfer;
 import com.onfido.model.MotionCapture;
-import java.io.File;
-import java.nio.file.Files;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
@@ -16,19 +15,23 @@ public class MotionCaptureTest extends TestBase {
 
   @Test
   public void downloadMotionCaptureTest() throws Exception {
-    File download = onfido.downloadMotionCapture(EXAMPLE_ID_1);
+    FileTransfer download = onfido.downloadMotionCapture(EXAMPLE_ID_1);
 
-    Assertions.assertTrue(download.length() > 0);
+    Assertions.assertEquals("video/mp4", download.getContentType());
+    Assertions.assertTrue(download.getFilename() != null);
+    Assertions.assertTrue(download.getByteArray().length > 0);
   }
 
   @Test
   public void downloadMotionCaptureFrameTest() throws Exception {
     try {
-      File download = onfido.downloadMotionCaptureFrame(EXAMPLE_ID_1);
-      byte[] content = Files.readAllBytes(download.toPath());
+      FileTransfer download = onfido.downloadMotionCaptureFrame(EXAMPLE_ID_1);
+      byte[] byteArray = download.getByteArray();
 
-      Assertions.assertTrue(download.length() > 0);
-      Assertions.assertEquals("JFIF", new String(content, 6, 4));
+      Assertions.assertEquals("image/jpeg", download.getContentType());
+      Assertions.assertTrue(download.getFilename() != null);
+      Assertions.assertTrue(byteArray.length > 0);
+      Assertions.assertEquals("JFIF", new String(byteArray, 6, 4));
     } catch (ApiException ex) {
       Assertions.assertEquals(422, ex.getCode());
       Assertions.assertEquals(

--- a/src/test/java/com/onfido/integration/ReportSchemasTest.java
+++ b/src/test/java/com/onfido/integration/ReportSchemasTest.java
@@ -3,6 +3,7 @@ package com.onfido.integration;
 import static com.onfido.model.ReportStatus.COMPLETE;
 
 import com.onfido.model.*;
+import java.time.LocalDate;
 import java.util.*;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,6 +39,17 @@ public class ReportSchemasTest extends TestBase {
     Assertions.assertNotNull(documentReport.getProperties());
     Assertions.assertNotNull(documentReport.getResult());
     Assertions.assertNotNull(documentReport.getSubResult());
+
+    Assertions.assertEquals(
+        "clear",
+        documentReport
+            .getBreakdown()
+            .getDataComparison()
+            .getBreakdown()
+            .getIssuingCountry()
+            .getResult());
+    Assertions.assertEquals(
+        LocalDate.parse("1990-01-01"), documentReport.getProperties().getDateOfBirth());
   }
 
   @Test

--- a/src/test/java/com/onfido/integration/TestBase.java
+++ b/src/test/java/com/onfido/integration/TestBase.java
@@ -2,6 +2,7 @@ package com.onfido.integration;
 
 import com.onfido.ApiException;
 import com.onfido.Configuration;
+import com.onfido.FileTransfer;
 import com.onfido.api.DefaultApi;
 import com.onfido.model.Applicant;
 import com.onfido.model.ApplicantBuilder;
@@ -22,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -79,6 +81,7 @@ public class TestBase {
   protected Document uploadDocument(Applicant applicant, String filename, String document_type)
       throws IOException, InterruptedException, ApiException {
     File file = new File("media/" + filename);
+    byte[] byteArray = Files.readAllBytes(file.toPath());
 
     LocationBuilder locationBuilder =
         new LocationBuilder().ipAddress("127.0.0.1").countryOfResidence(CountryCodes.GBR);
@@ -86,7 +89,7 @@ public class TestBase {
     return onfido.uploadDocument(
         document_type,
         applicant.getId(),
-        file,
+        new FileTransfer(byteArray, filename),
         null,
         "front",
         CountryCodes.USA,
@@ -95,11 +98,12 @@ public class TestBase {
   }
 
   protected LivePhoto uploadLivePhoto(Applicant applicant, String filename) throws Exception {
-    return onfido.uploadLivePhoto(applicant.getId(), new File("media/" + filename), true);
+    return onfido.uploadLivePhoto(
+        applicant.getId(), new FileTransfer(new File("media/" + filename)), true);
   }
 
   protected IdPhoto uploadIdPhoto(Applicant applicant, String filename) throws Exception {
-    return onfido.uploadIdPhoto(applicant.getId(), new File("media/" + filename));
+    return onfido.uploadIdPhoto(applicant.getId(), new FileTransfer(new File("media/" + filename)));
   }
 
   protected Check createCheck(Applicant applicant, Document document, CheckBuilder checkBuilder)

--- a/src/test/java/com/onfido/integration/WorkflowRunTest.java
+++ b/src/test/java/com/onfido/integration/WorkflowRunTest.java
@@ -1,10 +1,9 @@
 package com.onfido.integration;
 
+import com.onfido.FileTransfer;
 import com.onfido.model.TimelineFileReference;
 import com.onfido.model.WorkflowRun;
 import com.onfido.model.WorkflowRunBuilder;
-import java.io.File;
-import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -62,11 +61,10 @@ public class WorkflowRunTest extends TestBase {
 
   @Test
   public void evidenceWorkflowRunTest() throws Exception {
-    File download = onfido.downloadSignedEvidenceFile(workflowRunId);
-    byte[] content = Files.readAllBytes(download.toPath());
+    byte[] byteArray = onfido.downloadSignedEvidenceFile(workflowRunId).getByteArray();
 
-    Assertions.assertEquals("%PDF", new String(content, 0, 4));
-    Assertions.assertTrue(download.length() > 0);
+    Assertions.assertEquals("%PDF", new String(byteArray, 0, 4));
+    Assertions.assertTrue(byteArray.length > 0);
   }
 
   @Test
@@ -91,15 +89,14 @@ public class WorkflowRunTest extends TestBase {
         "findWorkflowRun", new UUID[] {workflowRunId}, WorkflowRun.StatusEnum.APPROVED, 10, 1000);
     UUID timelineFileId = onfido.createTimelineFile(workflowRunId).getWorkflowTimelineFileId();
 
-    File download =
-        (File)
+    FileTransfer download =
+        (FileTransfer)
             repeatRequestUntilHttpCodeChanges(
                 "findTimelineFile", new UUID[] {workflowRunId, timelineFileId}, 10, 1000);
 
-    onfido.findTimelineFile(workflowRunId, timelineFileId);
-    byte[] content = Files.readAllBytes(download.toPath());
+    byte[] byteArray = download.getByteArray();
 
-    Assertions.assertEquals("%PDF", new String(content, 0, 4));
-    Assertions.assertTrue(download.length() > 0);
+    Assertions.assertEquals("%PDF", new String(byteArray, 0, 4));
+    Assertions.assertTrue(byteArray.length > 0);
   }
 }


### PR DESCRIPTION
Auto-generated PR with changes till commit onfido/onfido-openapi-spec@e92d340b84690cce6851fa4a32530ac29911d75a (included)

Additional changes:
  - [Use FileTransfer object in tests](https://github.com/onfido/onfido-java/pull/118/commits/272564a9a42963166c50b3b87f71162e31b84558)