### PR TITLE
test: wait for evidence folder to be available

### DIFF
--- a/src/test/java/com/onfido/integration/ReportSchemasTest.java
+++ b/src/test/java/com/onfido/integration/ReportSchemasTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.Test;
 public class ReportSchemasTest extends TestBase {
   private Applicant applicant;
   private Document document;
+  private final int MAX_RETRIES = 15;
+  private final int SLEEP_TIME = 1000;
 
   @BeforeEach
   public void setup() throws Exception {
@@ -31,7 +33,11 @@ public class ReportSchemasTest extends TestBase {
     Report documentReport =
         (Report)
             repeatRequestUntilStatusChanges(
-                "findReport", new Object[] {check.getReportIds().get(0)}, COMPLETE, 10, 1000);
+                "findReport",
+                new Object[] {check.getReportIds().get(0)},
+                COMPLETE,
+                MAX_RETRIES,
+                SLEEP_TIME);
 
     Assertions.assertEquals(COMPLETE, documentReport.getStatus());
     Assertions.assertEquals(ReportName.DOCUMENT, documentReport.getName());
@@ -77,7 +83,11 @@ public class ReportSchemasTest extends TestBase {
     Report facialSimilarityPhotoFullyAutoReport =
         (Report)
             repeatRequestUntilStatusChanges(
-                "findReport", new Object[] {check.getReportIds().get(0)}, COMPLETE, 10, 1000);
+                "findReport",
+                new Object[] {check.getReportIds().get(0)},
+                COMPLETE,
+                MAX_RETRIES,
+                SLEEP_TIME);
 
     Assertions.assertEquals(COMPLETE, facialSimilarityPhotoFullyAutoReport.getStatus());
     Assertions.assertEquals(
@@ -118,7 +128,11 @@ public class ReportSchemasTest extends TestBase {
     Report report =
         (Report)
             repeatRequestUntilStatusChanges(
-                "findReport", new Object[] {check.getReportIds().get(0)}, COMPLETE, 10, 1000);
+                "findReport",
+                new Object[] {check.getReportIds().get(0)},
+                COMPLETE,
+                MAX_RETRIES,
+                SLEEP_TIME);
 
     Assertions.assertEquals(COMPLETE, report.getStatus());
     Assertions.assertEquals(ReportName.DOCUMENT_WITH_ADDRESS_INFORMATION, report.getName());
@@ -150,7 +164,11 @@ public class ReportSchemasTest extends TestBase {
     Report report =
         (Report)
             repeatRequestUntilStatusChanges(
-                "findReport", new Object[] {check.getReportIds().get(0)}, COMPLETE, 10, 1000);
+                "findReport",
+                new Object[] {check.getReportIds().get(0)},
+                COMPLETE,
+                MAX_RETRIES,
+                SLEEP_TIME);
 
     Assertions.assertEquals(COMPLETE, report.getStatus());
     Assertions.assertEquals(ReportName.FACIAL_SIMILARITY_PHOTO_FULLY_AUTO, report.getName());

--- a/src/test/java/com/onfido/integration/ReportSchemasTest.java
+++ b/src/test/java/com/onfido/integration/ReportSchemasTest.java
@@ -12,8 +12,6 @@ import org.junit.jupiter.api.Test;
 public class ReportSchemasTest extends TestBase {
   private Applicant applicant;
   private Document document;
-  private final int MAX_RETRIES = 15;
-  private final int SLEEP_TIME = 1000;
 
   @BeforeEach
   public void setup() throws Exception {

--- a/src/test/java/com/onfido/integration/ReportTest.java
+++ b/src/test/java/com/onfido/integration/ReportTest.java
@@ -24,8 +24,6 @@ import org.junit.jupiter.api.Test;
 public class ReportTest extends TestBase {
   private Document document;
   private Check check;
-  private final int MAX_RETRIES = 15;
-  private final int SLEEP_TIME = 1000;
 
   @BeforeEach
   public void setup() throws Exception {

--- a/src/test/java/com/onfido/integration/ReportTest.java
+++ b/src/test/java/com/onfido/integration/ReportTest.java
@@ -4,7 +4,6 @@ import com.onfido.model.Applicant;
 import com.onfido.model.Check;
 import com.onfido.model.CheckBuilder;
 import com.onfido.model.Document;
-import com.onfido.model.DocumentBreakdown;
 import com.onfido.model.DocumentReport;
 import com.onfido.model.DocumentTypes;
 import com.onfido.model.IdentityEnhancedProperties;
@@ -23,13 +22,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class ReportTest extends TestBase {
-  private Applicant applicant;
   private Document document;
   private Check check;
+  private final int MAX_RETRIES = 15;
+  private final int SLEEP_TIME = 1000;
 
   @BeforeEach
   public void setup() throws Exception {
-    applicant = createApplicant();
+    Applicant applicant = createApplicant();
     document =
         uploadDocument(applicant, "sample_driving_licence.png", DocumentTypes.DRIVING_LICENCE);
     check =
@@ -54,13 +54,26 @@ public class ReportTest extends TestBase {
       List<Report> reports =
           sortReports(
               Arrays.asList(
-                  onfido.findReport(reportIds.get(0)), onfido.findReport(reportIds.get(1))));
+                  (Report)
+                      repeatRequestUntilStatusChanges(
+                          "findReport",
+                          new Object[] {reportIds.get(0)},
+                          ReportStatus.COMPLETE,
+                          MAX_RETRIES,
+                          SLEEP_TIME),
+                  (Report)
+                      repeatRequestUntilStatusChanges(
+                          "findReport",
+                          new Object[] {reportIds.get(1)},
+                          ReportStatus.COMPLETE,
+                          MAX_RETRIES,
+                          SLEEP_TIME)));
 
       DocumentReport documentReport = reports.get(0).getDocumentReport();
       IdentityEnhancedReport identityEnhancedReport = reports.get(1).getIdentityEnhancedReport();
 
       Assertions.assertEquals(ReportName.DOCUMENT, documentReport.getName());
-      Assertions.assertEquals(ReportStatus.AWAITING_DATA, documentReport.getStatus());
+      Assertions.assertEquals(ReportStatus.COMPLETE, documentReport.getStatus());
 
       Assertions.assertEquals(ReportName.IDENTITY_ENHANCED, identityEnhancedReport.getName());
       Assertions.assertEquals(check.getId(), identityEnhancedReport.getCheckId());
@@ -70,7 +83,6 @@ public class ReportTest extends TestBase {
       Assertions.assertNotNull(documents);
       Assertions.assertEquals(documents.get(0).getId(), document.getId());
 
-      Assertions.assertEquals(new DocumentBreakdown(), documentReport.getBreakdown());
       Assertions.assertEquals(
           new IdentityEnhancedProperties(), identityEnhancedReport.getProperties());
     } else {

--- a/src/test/java/com/onfido/integration/TestBase.java
+++ b/src/test/java/com/onfido/integration/TestBase.java
@@ -27,6 +27,9 @@ public class TestBase {
   protected static final UUID nonExistingId =
       UUID.fromString("00000000-0000-0000-0000-000000000000");
 
+  protected final int MAX_RETRIES = 15;
+  protected final int SLEEP_TIME = 1000;
+
   protected DefaultApi onfido;
 
   public TestBase() {

--- a/src/test/java/com/onfido/integration/WorkflowRunOutputsTest.java
+++ b/src/test/java/com/onfido/integration/WorkflowRunOutputsTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.Test;
 public class WorkflowRunOutputsTest extends TestBase {
   private Applicant applicant;
   private final Gson gson = new Gson();
+  private final int MAX_RETRIES = 15;
+  private final int SLEEP_TIME = 1000;
 
   @BeforeEach
   public void setup() throws Exception {
@@ -87,8 +89,8 @@ public class WorkflowRunOutputsTest extends TestBase {
                 "findWorkflowRun",
                 new UUID[] {workflowRunId},
                 WorkflowRunStatus.APPROVED,
-                10,
-                1000);
+                MAX_RETRIES,
+                SLEEP_TIME);
 
     Assertions.assertEquals(WorkflowRunStatus.APPROVED, workflowRun.getStatus());
 

--- a/src/test/java/com/onfido/integration/WorkflowRunOutputsTest.java
+++ b/src/test/java/com/onfido/integration/WorkflowRunOutputsTest.java
@@ -12,8 +12,6 @@ import org.junit.jupiter.api.Test;
 public class WorkflowRunOutputsTest extends TestBase {
   private Applicant applicant;
   private final Gson gson = new Gson();
-  private final int MAX_RETRIES = 15;
-  private final int SLEEP_TIME = 1000;
 
   @BeforeEach
   public void setup() throws Exception {

--- a/src/test/java/com/onfido/integration/WorkflowRunTest.java
+++ b/src/test/java/com/onfido/integration/WorkflowRunTest.java
@@ -23,8 +23,6 @@ public class WorkflowRunTest extends TestBase {
   static final UUID WORKFLOW_ID = UUID.fromString("e8c921eb-0495-44fe-b655-bcdcaffdafe5");
   static final UUID WORKFLOW_ID_AUTO_APPROVE =
       UUID.fromString("221f9d24-cf72-4762-ac4a-01bf3ccc09dd");
-  private final int MAX_RETRIES = 15;
-  private final int SLEEP_TIME = 1000;
 
   @BeforeEach
   public void setup() throws Exception {

--- a/src/test/java/com/onfido/integration/WorkflowRunTest.java
+++ b/src/test/java/com/onfido/integration/WorkflowRunTest.java
@@ -23,6 +23,8 @@ public class WorkflowRunTest extends TestBase {
   static final UUID WORKFLOW_ID = UUID.fromString("e8c921eb-0495-44fe-b655-bcdcaffdafe5");
   static final UUID WORKFLOW_ID_AUTO_APPROVE =
       UUID.fromString("221f9d24-cf72-4762-ac4a-01bf3ccc09dd");
+  private final int MAX_RETRIES = 15;
+  private final int SLEEP_TIME = 1000;
 
   @BeforeEach
   public void setup() throws Exception {
@@ -83,7 +85,11 @@ public class WorkflowRunTest extends TestBase {
     UUID workflowRunId = createWorkflowRun(WORKFLOW_ID_AUTO_APPROVE, applicantId).getId();
 
     repeatRequestUntilStatusChanges(
-        "findWorkflowRun", new UUID[] {workflowRunId}, WorkflowRunStatus.APPROVED, 10, 1000);
+        "findWorkflowRun",
+        new UUID[] {workflowRunId},
+        WorkflowRunStatus.APPROVED,
+        MAX_RETRIES,
+        SLEEP_TIME);
     TimelineFileReference workflowTimelineFileData = onfido.createTimelineFile(workflowRunId);
 
     Assertions.assertNotNull(workflowTimelineFileData.getWorkflowTimelineFileId());
@@ -97,13 +103,20 @@ public class WorkflowRunTest extends TestBase {
     UUID workflowRunId = createWorkflowRun(WORKFLOW_ID_AUTO_APPROVE, applicantId).getId();
 
     repeatRequestUntilStatusChanges(
-        "findWorkflowRun", new UUID[] {workflowRunId}, WorkflowRunStatus.APPROVED, 10, 1000);
+        "findWorkflowRun",
+        new UUID[] {workflowRunId},
+        WorkflowRunStatus.APPROVED,
+        MAX_RETRIES,
+        SLEEP_TIME);
     UUID timelineFileId = onfido.createTimelineFile(workflowRunId).getWorkflowTimelineFileId();
 
     FileTransfer download =
         (FileTransfer)
             repeatRequestUntilHttpCodeChanges(
-                "findTimelineFile", new UUID[] {workflowRunId, timelineFileId}, 10, 1000);
+                "findTimelineFile",
+                new UUID[] {workflowRunId, timelineFileId},
+                MAX_RETRIES,
+                SLEEP_TIME);
 
     byte[] byteArray = download.getByteArray();
 
@@ -116,9 +129,18 @@ public class WorkflowRunTest extends TestBase {
     UUID workflowRunId = createWorkflowRun(WORKFLOW_ID_AUTO_APPROVE, applicantId).getId();
 
     repeatRequestUntilStatusChanges(
-        "findWorkflowRun", new UUID[] {workflowRunId}, WorkflowRunStatus.APPROVED, 10, 1000);
+        "findWorkflowRun",
+        new UUID[] {workflowRunId},
+        WorkflowRunStatus.APPROVED,
+        MAX_RETRIES,
+        SLEEP_TIME);
 
-    byte[] byteArray = onfido.downloadEvidenceFolder(workflowRunId).getByteArray();
+    FileTransfer evidenceFolderDownload =
+        (FileTransfer)
+            repeatRequestUntilHttpCodeChanges(
+                "downloadEvidenceFolder", new UUID[] {workflowRunId}, MAX_RETRIES, SLEEP_TIME);
+
+    byte[] byteArray = evidenceFolderDownload.getByteArray();
 
     Path path = Files.createTempFile("evidence-folder", ".zip");
     path.toFile().deleteOnExit();


### PR DESCRIPTION
Evidence folder needs to be available before it can be downloaded. Fix the test by retrying the request until we no longer receive 404.

I also did some extra changes (increasing number of retries) to reduce test flakiness.