### PR TITLE
Update Sonatype Staging Maven plugin version to allow delivery

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.7</version>
+                        <version>1.6.13</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>


### PR DESCRIPTION
Trying to solve issue at delivery time reported below:
https://github.com/onfido/onfido-java/actions/runs/13440014944/job/37552016229

By applying what suggested below:
https://stackoverflow.com/a/70157413