### PR TITLE
Update publishing configuration to use Central Publisher Portal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -253,15 +253,14 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.13</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.8.0</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                            <stagingProgressTimeoutMinutes>10</stagingProgressTimeoutMinutes>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                            <waitUntil>published</waitUntil>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -337,7 +337,7 @@
         <gson-fire-version>1.9.0</gson-fire-version>
         <okhttp-version>4.12.0</okhttp-version>
         <gson-version>2.10.1</gson-version>
-        <commons-lang3-version>3.17.0</commons-lang3-version>
+        <commons-lang3-version>3.18.0</commons-lang3-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>


### PR DESCRIPTION
Update publishing configuration to use Central Publisher Portal:
- https://central.sonatype.org/publish/publish-portal-maven/
- https://dev.to/mxro/migrating-maven-namespace-to-central-portal-fgp

Taking the opportunity to bump `org.apache.commons:commons-lang3` version from 3.17.0 to 3.18.0 to fix [vulnerability](https://github.com/onfido/onfido-java/security/dependabot/2). 