### PR TITLE
Update publishing configuration to use Central Publisher Portal (4)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,8 +259,10 @@
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central</publishingServerId>
+                            <deploymentName>onfido-api-java:${project.version}</deploymentName>
                             <autoPublish>true</autoPublish>
-                            <waitUntil>published</waitUntil>
+                            <waitUntil>validated</waitUntil>
+                            <timeout>PT30M</timeout>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,7 @@
                             <deploymentName>onfido-api-java:${project.version}</deploymentName>
                             <autoPublish>true</autoPublish>
                             <waitUntil>validated</waitUntil>
-                            <timeout>PT30M</timeout>
+                            <waitMaxTime>1800</waitMaxTime>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,6 @@
                             <deploymentName>onfido-api-java:${project.version}</deploymentName>
                             <autoPublish>true</autoPublish>
                             <waitUntil>validated</waitUntil>
-                            <waitMaxTime>1800</waitMaxTime>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
Add the deployment name which was missing. Wait until validated (instead of published); default timeout of 30 minutes ([doc](https://central.sonatype.org/publish/publish-portal-maven)) should be enough for that.