### PR TITLE
Fix CHANGELOG.md and improve CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,6 +18,10 @@ on:
       - published
   schedule:
     - cron: "0 13 * * 0"   # Every Sunday, 1 hour after midday
+
+permissions:
+  contents: read
+
 jobs:
   integration-tests:
     runs-on: ubuntu-latest
@@ -57,6 +61,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: integration-tests
     environment: delivery
+    permissions:
+      contents: write
     if: github.event_name == 'release'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -42,7 +42,8 @@ jobs:
       - name: Build with Maven
         run: mvn -B package --file pom.xml -Dmaven.test.skip
       - name: Run integration tests with Maven
-        if: ${{ github.repository_owner == 'onfido' }}
+        if: ${{ github.repository_owner == 'onfido' &&
+          (github.event_name == 'pull_request' || github.event_name == 'release') }}
         run: mvn test
         env:
           ONFIDO_API_TOKEN: ${{ secrets.ONFIDO_API_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Release based on Onfido OpenAPI spec version [v5.4.0](https://github.com/onfido/onfido-openapi-spec/releases/tag/v5.4.0):
   - [ENT-26] Add AES document download endpoint
+- [ENT-26] Add AES documents test
 
 ## v6.2.0 6th June 2025
 


### PR DESCRIPTION
Fix CHANGELOG.md and improve CI to not run tests when commit is not coming from a PR (i.e. CHANGELOG update performed by the CI).

Take the opportunity for fixing a few security vulnerabilities:
- https://github.com/onfido/onfido-java/security/code-scanning/1
- https://github.com/onfido/onfido-java/security/code-scanning/2
