### PR TITLE
Refresh onfido-java after onfido-openapi-spec update (4204f00)

### DIFF
--- a/.release.json
+++ b/.release.json
@@ -3,7 +3,7 @@
     "repo_url": "https://github.com/onfido/onfido-openapi-spec",
     "short_sha": "4204f00",
     "long_sha": "4204f00a2c7f0f5bd61da3b5442d8eb613418e9e",
-    "version": ""
+    "version": "v6.0.0"
   },
   "release": "v7.0.0"
 }

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -13,6 +13,7 @@ ensuring a smooth transition between versions.
 - **All API methods**: All API method calls now use request builder pattern with `.execute()`
   - This change enables backward compatibility when new optional parameters are added
   - Example migration:
+
     ```java
     // Before (v6.x)
     List<WorkflowRun> runs = api.listWorkflowRuns(applicantId, status, page, perPage);
@@ -25,6 +26,7 @@ ensuring a smooth transition between versions.
         .perPage(perPage)
         .execute();
     ```
+
 - Documents
   - Driving licence information properties removed from general `DocumentProperties`
     and moved to new `DocumentPropertiesWithDrivingLicenceInformation` class

--- a/src/test/java/com/onfido/integration/WorkflowRunTest.java
+++ b/src/test/java/com/onfido/integration/WorkflowRunTest.java
@@ -74,7 +74,15 @@ public class WorkflowRunTest extends TestBase {
 
   @Test
   public void evidenceWorkflowRunTest() throws Exception {
-    byte[] byteArray = onfido.downloadSignedEvidenceFile(workflowRunId).execute().getByteArray();
+    FileTransfer evidenceFile =
+        (FileTransfer)
+            repeatRequestUntilHttpCodeChanges(
+                "downloadSignedEvidenceFile",
+                new UUID[] {workflowRunId},
+                MAX_RETRIES,
+                SLEEP_TIME * 2);
+
+    byte[] byteArray = evidenceFile.getByteArray();
 
     Assertions.assertEquals("%PDF", new String(byteArray, 0, 4));
     Assertions.assertTrue(byteArray.length > 0);
@@ -118,7 +126,7 @@ public class WorkflowRunTest extends TestBase {
                 "findTimelineFile",
                 new UUID[] {workflowRunId, timelineFileId},
                 MAX_RETRIES,
-                SLEEP_TIME * 2);
+                SLEEP_TIME);
 
     byte[] byteArray = download.getByteArray();
 


### PR DESCRIPTION
Auto-generated PR with changes till commit onfido/onfido-openapi-spec@4204f00a2c7f0f5bd61da3b5442d8eb613418e9e (included)

Additional changes:
  - [Add retry logic with 30s timeout for evidence file downloads and fix findTimelineFile timeout](https://github.com/onfido/onfido-java/pull/176/changes/45acf99a56ac177b55471014b371ef4c4bb15ee4)