### PR TITLE
Document ReportShared object removal in migration guide

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -37,6 +37,26 @@ ensuring a smooth transition between versions.
 ### Other Endpoints
 
 - Reports
+  - **`ReportShared` object removed**: The `ReportShared` object has been dropped.
+    Convenience accessors for common fields (`getName()`, `getStatus()`, `getId()`)
+    have been added to the parent `Report` object. Other properties are now accessed
+    via specific report type accessors
+    - Example migration:
+
+      ```java
+      // Before (v6.x)
+      ReportName name = report.getReportShared().getName();
+      ReportStatus status = report.getReportShared().getStatus();
+      String checkId = report.getReportShared().getCheckId();
+      String result = report.getReportShared().getResult();
+
+      // After (v7.x)
+      ReportName name = report.getName(); // Convenience accessor on parent Report object
+      ReportStatus status = report.getStatus(); // Convenience accessor on parent Report object
+      String checkId = report.getDocumentReport().getCheckId(); // E.g. for document report
+      String result = report.getDocumentReport().getResult(); // E.g. for document report
+      ```
+
   - Device Intelligence: Removed deprecated `breakdown` property and related
     breakdown classes:
     - `DeviceIntelligenceBreakdownProperties` removed


### PR DESCRIPTION
### What Changed
Added missing documentation to the v6 → v7 migration guide for the `ReportShared` object removal.

### Details
- The `ReportShared` object has been dropped in v7
- Convenience accessors (`getName()`, `getStatus()`, `getId()`) added to parent `Report` object
- Other properties now accessed via specific report type accessors (e.g., `getDocumentReport()`)

### Migration Example
```java
// Before (v6.x)
ReportName name = report.getReportShared().getName();
String checkId = report.getReportShared().getCheckId();

// After (v7.x)
ReportName name = report.getName(); // Convenience accessor
String checkId = report.getDocumentReport().getCheckId(); // Via specific type