### PR TITLE
[CAT-2931] ci: add distributed lock for integration tests

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -53,7 +53,8 @@ jobs:
         if: steps.should-run-integration-tests.outputs.result == 'true'
         uses: onfido/onfido-actions/lock/acquire@add-lock-action
         with:
-          github-token: ${{ secrets.CI_LOCK_TOKEN }}
+          app-id: ${{ secrets.ONFIDO_CI_LOCK_APP_ID }}
+          app-private-key: ${{ secrets.ONFIDO_CI_LOCK_PRIVATE_KEY }}
       - name: Run integration tests with API token auth
         if: steps.should-run-integration-tests.outputs.result == 'true'
         run: mvn test
@@ -79,7 +80,8 @@ jobs:
         if: always() && steps.should-run-integration-tests.outputs.result == 'true'
         uses: onfido/onfido-actions/lock/release@add-lock-action
         with:
-          github-token: ${{ secrets.CI_LOCK_TOKEN }}
+          app-id: ${{ secrets.ONFIDO_CI_LOCK_APP_ID }}
+          app-private-key: ${{ secrets.ONFIDO_CI_LOCK_PRIVATE_KEY }}
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -48,10 +48,10 @@ jobs:
       - name: Should run integration tests
         id: should-run-integration-tests
         if: ${{ github.repository_owner == 'onfido' }}
-        uses: onfido/onfido-actions/should-run-integration-tests@add-lock-action
+        uses: onfido/onfido-actions/should-run-integration-tests@main
       - name: Acquire integration test lock
         if: steps.should-run-integration-tests.outputs.result == 'true'
-        uses: onfido/onfido-actions/lock/acquire@add-lock-action
+        uses: onfido/onfido-actions/lock/acquire@main
         with:
           app-id: ${{ secrets.ONFIDO_CI_LOCK_APP_ID }}
           app-private-key: ${{ secrets.ONFIDO_CI_LOCK_PRIVATE_KEY }}
@@ -78,7 +78,7 @@ jobs:
           ONFIDO_SAMPLE_MOTION_ID_2: ${{ secrets.ONFIDO_SAMPLE_MOTION_ID_2 }}
       - name: Release integration test lock
         if: always() && steps.should-run-integration-tests.outputs.result == 'true'
-        uses: onfido/onfido-actions/lock/release@add-lock-action
+        uses: onfido/onfido-actions/lock/release@main
         with:
           app-id: ${{ secrets.ONFIDO_CI_LOCK_APP_ID }}
           app-private-key: ${{ secrets.ONFIDO_CI_LOCK_PRIVATE_KEY }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -45,12 +45,21 @@ jobs:
             ${{ runner.os }}-maven-
       - name: Build with Maven
         run: mvn -B package --file pom.xml -Dmaven.test.skip
-      - name: Run integration tests with API token auth
+      - name: Should run integration tests
+        id: should-run-integration-tests
         if: ${{ github.repository_owner == 'onfido' &&
           (github.event_name == 'pull_request' ||
            github.event_name == 'release' ||
            github.event_name == 'workflow_dispatch' ||
            github.event_name == 'schedule') }}
+        run: echo "result=true" >> "$GITHUB_OUTPUT"
+      - name: Acquire integration test lock
+        if: steps.should-run-integration-tests.outputs.result == 'true'
+        uses: onfido/onfido-actions/lock/acquire@main
+        with:
+          github-token: ${{ secrets.CI_LOCK_TOKEN }}
+      - name: Run integration tests with API token auth
+        if: steps.should-run-integration-tests.outputs.result == 'true'
         run: mvn test
         env:
           ONFIDO_API_TOKEN: ${{ secrets.ONFIDO_API_TOKEN }}
@@ -60,11 +69,7 @@ jobs:
           ONFIDO_SAMPLE_MOTION_ID_1: ${{ secrets.ONFIDO_SAMPLE_MOTION_ID_1 }}
           ONFIDO_SAMPLE_MOTION_ID_2: ${{ secrets.ONFIDO_SAMPLE_MOTION_ID_2 }}
       - name: Run integration tests with OAuth client credentials auth
-        if: ${{ github.repository_owner == 'onfido' &&
-          (github.event_name == 'pull_request' ||
-           github.event_name == 'release' ||
-           github.event_name == 'workflow_dispatch' ||
-           github.event_name == 'schedule') }}
+        if: steps.should-run-integration-tests.outputs.result == 'true'
         run: mvn test
         env:
           ONFIDO_OAUTH_CLIENT_ID: ${{ secrets.ONFIDO_OAUTH_CLIENT_ID }}
@@ -74,6 +79,11 @@ jobs:
           ONFIDO_SAMPLE_VIDEO_ID_2: ${{ secrets.ONFIDO_SAMPLE_VIDEO_ID_2 }}
           ONFIDO_SAMPLE_MOTION_ID_1: ${{ secrets.ONFIDO_SAMPLE_MOTION_ID_1 }}
           ONFIDO_SAMPLE_MOTION_ID_2: ${{ secrets.ONFIDO_SAMPLE_MOTION_ID_2 }}
+      - name: Release integration test lock
+        if: always() && steps.should-run-integration-tests.outputs.result == 'true'
+        uses: onfido/onfido-actions/lock/release@main
+        with:
+          github-token: ${{ secrets.CI_LOCK_TOKEN }}
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -47,12 +47,8 @@ jobs:
         run: mvn -B package --file pom.xml -Dmaven.test.skip
       - name: Should run integration tests
         id: should-run-integration-tests
-        if: ${{ github.repository_owner == 'onfido' &&
-          (github.event_name == 'pull_request' ||
-           github.event_name == 'release' ||
-           github.event_name == 'workflow_dispatch' ||
-           github.event_name == 'schedule') }}
-        run: echo "result=true" >> "$GITHUB_OUTPUT"
+        if: ${{ github.repository_owner == 'onfido' }}
+        uses: onfido/onfido-actions/should-run-integration-tests@add-lock-action
       - name: Acquire integration test lock
         if: steps.should-run-integration-tests.outputs.result == 'true'
         uses: onfido/onfido-actions/lock/acquire@add-lock-action

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -55,7 +55,7 @@ jobs:
         run: echo "result=true" >> "$GITHUB_OUTPUT"
       - name: Acquire integration test lock
         if: steps.should-run-integration-tests.outputs.result == 'true'
-        uses: onfido/onfido-actions/lock/acquire@main
+        uses: onfido/onfido-actions/lock/acquire@add-lock-action
         with:
           github-token: ${{ secrets.CI_LOCK_TOKEN }}
       - name: Run integration tests with API token auth
@@ -81,7 +81,7 @@ jobs:
           ONFIDO_SAMPLE_MOTION_ID_2: ${{ secrets.ONFIDO_SAMPLE_MOTION_ID_2 }}
       - name: Release integration test lock
         if: always() && steps.should-run-integration-tests.outputs.result == 'true'
-        uses: onfido/onfido-actions/lock/release@main
+        uses: onfido/onfido-actions/lock/release@add-lock-action
         with:
           github-token: ${{ secrets.CI_LOCK_TOKEN }}
 


### PR DESCRIPTION
Prevents integration tests from running in parallel across SDK repositories by using a distributed lock via [onfido-actions/lock](https://github.com/onfido/onfido-actions).

**Changes:**
- Add `should-run-integration-tests` action to determine when tests should run
- Acquire/release a cross-repo lock around integration tests