### PR TITLE
ci: upgrade to JDK 21 and google-java-format 2.3.0

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 21 for linter
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           java-version: "21"
@@ -36,11 +36,6 @@ jobs:
         run: |
           npm install google-java-format@2.3.0
           npx google-java-format --set-exit-if-changed -i $(git ls-files src/test/\*.java)
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: "17"
-          distribution: "adopt"
       - name: Cache local Maven repository
         uses: actions/cache@v4
         with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,15 +27,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set up JDK 21 for linter
+        uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: "temurin"
+      - name: Install and run linter over tests
+        run: |
+          npm install google-java-format@2.3.0
+          npx google-java-format --set-exit-if-changed -i $(git ls-files src/test/\*.java)
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           java-version: "17"
           distribution: "adopt"
-      - name: Install and run linter over tests
-        run: |
-          npm install google-java-format@1.4.0
-          npx google-java-format --set-exit-if-changed -i $(git ls-files src/test/\*.java)
       - name: Cache local Maven repository
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Problem

CI fails with:
```
Error: google-java-format exited with exit code 1.
```

- `google-java-format@1.4.0` is incompatible with JDK 17+
- The latest version (`2.3.0`) requires **JDK 21** to run

## Changes

- Upgraded `google-java-format` from `1.4.0` to `2.3.0`
- Upgraded CI JDK from 17 (adopt) to **21 (temurin)** for linting and build/tests
- The project still compiles to Java 1.8 bytecode, so JDK 21 is fully backwards-compatible

## Rationale

- JDK 17 EOL is ~October 2027; JDK 21 (LTS) is supported until 2029
- google-java-format upstream now requires JDK 21 as minimum runtime
- Simplifies the workflow to a single JDK setup step

## Notes

- Formatting rules may differ slightly between versions, so test files may need a one-time reformat if the linter step fails with `--set-exit-if-changed`